### PR TITLE
Add support for local variables

### DIFF
--- a/compiler.cpp
+++ b/compiler.cpp
@@ -59,21 +59,21 @@ void byteCodeToText(std::vector<uint8_t> const &bytecode)
 }
 int main()
 {
-    // std::string code = "a = 2; if(a) { print(a); print(b)} elif(c) {test1()} else {print(0)}";
-    std::string code = R"CLM(a = array(3);
-a[0] = 6;
-a[2] = 9;
-c = a[2];
-print(a[0]);
-if(a[0] == 6) {
-    print("you stupid");
-    if (c == a[2]){
-        print(a[1]);
-        }
-}
-elif (a[0] == 0) {
-    print("lmao");
-})CLM";
+    // std::string code = R"CLM(let a = 90;a = 10;)CLM";
+    std::string code = R"CLM(let a = 90;
+   
+    a = 10;
+    d = "this is global";
+    let b = 90;
+    print(a == b);
+    let c = a + b;
+    if(a == b){
+        let d = c;
+        print(d + d);
+    } else {
+        let d = a;
+    }
+    print(d);)CLM";
     std::cout << "Source: " << code << std::endl;
     GobLang::Compiler::Parser comp(code);
     comp.parse();
@@ -83,17 +83,25 @@ elif (a[0] == 0) {
     compiler.compile();
     compiler.printCode();
     compiler.generateByteCode();
-    byteCodeToText(compiler.getByteCode().operations);
+    //byteCodeToText(compiler.getByteCode().operations);
     std::cout << "Executing code" << std::endl;
     GobLang::Machine machine(compiler.getByteCode());
-    machine.createVariable("piss", GobLang::MemoryValue{.type = GobLang::Type::Int, .value = 69});
     machine.addFunction(MachineFunctions::printLine, "print");
     machine.addFunction(MachineFunctions::createArrayOfSize, "array");
     machine.addFunction(test1, "test1");
+    std::vector<size_t> debugPoints = {};
     while (!machine.isAtTheEnd())
     {
+        if (std::find(debugPoints.begin(), debugPoints.end(), machine.getProgramCounter()) != debugPoints.end())
+        {
+            std::cout << "Debugging at " << std::hex << machine.getProgramCounter() << std::dec << std::endl;
+            machine.printGlobalsInfo();
+            machine.printVariablesInfo();
+            machine.printStack();
+        }
         machine.step();
     }
+
     // std::cout << "Value of a = " << std::get<int32_t>(machine.getVariableValue("a").value) << std::endl;
     return EXIT_SUCCESS;
 }

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -61,9 +61,13 @@ int main()
 {
     // std::string code = R"CLM(let a = 90;a = 10;)CLM";
     std::string code = R"CLM(let a = 90;
-   
     a = 10;
     d = "this is global";
+    let arrTest = array(8);
+    arrTest[2] = d;
+    arrTest[0] = 2;
+    arrTest[1] = array(3);
+    arrTest[1][1] = "Depth";
     let b = 90;
     print(a == b);
     let c = a + b;
@@ -73,7 +77,8 @@ int main()
     } else {
         let d = a;
     }
-    print(d);)CLM";
+    print(d);
+    print(arrTest))CLM";
     std::cout << "Source: " << code << std::endl;
     GobLang::Compiler::Parser comp(code);
     comp.parse();

--- a/compiler/Compiler.hpp
+++ b/compiler/Compiler.hpp
@@ -56,17 +56,19 @@ namespace GobLang::Compiler
 
         static std::vector<uint8_t> generateSetByteCode(Token *token);
 
-        //void appendByteCode(std::vector<uint8_t> const &code);
+        // void appendByteCode(std::vector<uint8_t> const &code);
 
         /**
          * @brief Generate and add byte code for the given compiler node. If node has mark attached this mark will be updated
-         * 
+         *
          * @param node Node to process
          * @param getter If true getter code will be generated, otherwise false
          */
         void appendCompilerNode(CompilerNode *node, bool getter);
 
         void addNewMarkReplacement(size_t mark, size_t address);
+
+        void appendByteCode(std::vector<uint8_t> const& bytes);
 
         ByteCode getByteCode() const { return m_byteCode; }
 
@@ -75,6 +77,11 @@ namespace GobLang::Compiler
         ~Compiler();
 
     private:
+        bool _doesVariableExist(size_t stringId);
+        int32_t _getLocalVariableAccessId(size_t id);
+        void _appendVariableBlock();
+        void _popVariableBlock();
+        void _appendVariable(size_t stringId);
         void _placeAddressForMark(size_t mark, size_t address, bool erase);
         void _compileSeparators(SeparatorToken *sepToken, std::vector<Token *>::const_iterator const &it);
 
@@ -91,6 +98,9 @@ namespace GobLang::Compiler
         std::vector<uint8_t> m_bytes;
 
         std::vector<Token *> m_stack;
+        std::vector<SeparatorToken *> m_blockDepthStack;
+
+        std::vector<std::vector<size_t>> m_blockVariables = {{}};
 
         std::vector<GotoToken *> m_jumps;
 
@@ -100,7 +110,7 @@ namespace GobLang::Compiler
          *
          */
         std::map<size_t, std::vector<size_t>> m_jumpMarks;
-        
+
         std::map<size_t, size_t> m_jumpDestinations;
         /**
          * @brief Array for storing all tokens created during the conversion process, used only to be able to delete them once the process ends
@@ -115,6 +125,8 @@ namespace GobLang::Compiler
 
         bool m_isInConditionHead = false;
         size_t m_markCounter = 0;
+
+        bool m_isVariableDeclaration = false;
     };
 
 }

--- a/compiler/CompilerNode.hpp
+++ b/compiler/CompilerNode.hpp
@@ -51,6 +51,14 @@ namespace GobLang::Compiler
         Token *m_token;
     };
 
+    class LocalVarTokenCompilerNode : public TokenCompilerNode
+    {
+    public:
+        explicit LocalVarTokenCompilerNode(Token *token,
+                                           bool isDestination,
+                                           size_t destinationId) : TokenCompilerNode(token, isDestination, destinationId) {}
+    };
+
     class ArrayCompilerNode : public CompilerNode
     {
     public:

--- a/compiler/CompilerToken.hpp
+++ b/compiler/CompilerToken.hpp
@@ -37,4 +37,16 @@ namespace GobLang::Compiler
     private:
         bool m_value;
     };
+
+    class LocalVarToken : public Token
+    {
+    public:
+        explicit LocalVarToken(size_t row, size_t column, size_t id) : Token(row, column), m_varId(id) {}
+        size_t getId() const { return m_varId; }
+
+        std::string toString() override { return "LOC" + std::to_string(m_varId); }
+
+    private:
+        size_t m_varId;
+    };
 }

--- a/compiler/Lexems.hpp
+++ b/compiler/Lexems.hpp
@@ -8,6 +8,7 @@ namespace GobLang::Compiler
     {
         Int,
         Float,
+        Let,
         Function,
         Return,
         Null,
@@ -76,7 +77,8 @@ namespace GobLang::Compiler
         {"false", Keyword::False},
         {"if", Keyword::If},
         {"elif", Keyword::Elif},
-        {"else", Keyword::Else}};
+        {"else", Keyword::Else},
+        {"let", Keyword::Let}};
 
     /**
      * @brief Static array containing info about all operators used in the compiler

--- a/execution/Array.cpp
+++ b/execution/Array.cpp
@@ -1,5 +1,4 @@
 #include "Array.hpp"
-
 #include "Value.hpp"
 GobLang::ArrayNode::ArrayNode(size_t size)
 {
@@ -20,4 +19,18 @@ GobLang::MemoryValue *GobLang::ArrayNode::getItem(size_t i)
     {
         return nullptr;
     }
+}
+
+std::string GobLang::ArrayNode::toString()
+{
+    std::string text = "[";
+    for (size_t i = 0; i < m_data.size(); i++)
+    {
+        text += valueToString(m_data[i]);
+        if (i != m_data.size() - 1)
+        {
+            text += ",";
+        }
+    }
+    return text + "]";
 }

--- a/execution/Array.hpp
+++ b/execution/Array.hpp
@@ -14,6 +14,8 @@ namespace GobLang
         void setItem(size_t i, MemoryValue const &item);
         MemoryValue *getItem(size_t i);
 
+        std::string toString() override;
+
     private:
         std::vector<MemoryValue> m_data;
     };

--- a/execution/Machine.hpp
+++ b/execution/Machine.hpp
@@ -16,8 +16,8 @@
 namespace GobLang
 {
     /**
-     * @brief Type used to store jump addresses in the code 
-     * 
+     * @brief Type used to store jump addresses in the code
+     *
      */
     using ProgramAddressType = size_t;
     class Machine
@@ -56,22 +56,44 @@ namespace GobLang
 
         bool isAtTheEnd() const
         {
-            return m_programCounter >= m_operations.size() || m_forcedEnd ;
+            return m_programCounter >= m_operations.size() || m_forcedEnd;
         }
         void addFunction(FunctionValue const &func, std::string const &name);
         void step();
 
+        void printGlobalsInfo();
+
+        void printVariablesInfo();
+
+        void printStack();
+
         MemoryValue *getStackTop();
 
-        MemoryValue * getStackTopAndPop();
+        MemoryValue *getStackTopAndPop();
 
-        ArrayNode* createArrayOfSize(int32_t size);
+        ArrayNode *createArrayOfSize(int32_t size);
 
         void popStack();
 
-        void pushToStack(MemoryValue const& val);
+        void pushToStack(MemoryValue const &val);
 
-        MemoryValue getVariableValue(std::string const &name) { return m_variables[name]; }
+        MemoryValue getVariableValue(std::string const &name) { return m_globals[name]; }
+
+        /**
+         * @brief Set local variable value using id. If id is larger than current amount of variables the array will be expanded to match the id
+         * 
+         * @param id id of the variable
+         * @param val Value of the variable
+         */
+        void setLocalVariableValue(size_t id, MemoryValue const &val);
+
+        /**
+         * @brief Get value of a local variable. Beware that addressing id that is no longer in use by the block that created it is undefined behaviour
+         * 
+         * @param id Id of the local variable
+         * @return MemoryValue* Value of the local variable or nullptr if no value uses this id
+         */
+        MemoryValue *getLocalVariableValue(size_t id);
 
         /**
          * @brief Create a custom variable that will be accessible in code. Useful for binding with c code
@@ -92,7 +114,7 @@ namespace GobLang
         void _jump();
 
         void _jumpIf();
-        
+
         void _addInt();
 
         void _subInt();
@@ -100,6 +122,10 @@ namespace GobLang
         void _set();
 
         void _get();
+
+        void _setLocal();
+
+        void _getLocal();
 
         void _call();
 
@@ -119,7 +145,18 @@ namespace GobLang
         size_t m_programCounter = 0;
         std::vector<uint8_t> m_operations;
         std::vector<MemoryValue> m_operationStack;
-        std::map<std::string, MemoryValue> m_variables;
+        /**
+         * @brief Special dictionary that can be written externally and internally which uses strings to identify variables.
+         *
+         * Any variable that doesn't have a valid local variable attached will attempt to read a global variable value
+         */
+        std::map<std::string, MemoryValue> m_globals;
+        /**
+         * @brief Array of currently present local variables.
+         *  These variables can only be addressed by their index and will be overriden once the id is used in a different block
+         *
+         */
+        std::vector<MemoryValue> m_variables;
         std::vector<int32_t> m_constInts;
         std::vector<float> m_constFloats;
         std::vector<std::string> m_constStrings;

--- a/execution/Operations.hpp
+++ b/execution/Operations.hpp
@@ -12,6 +12,8 @@ namespace GobLang
         Call,
         Set,
         Get,
+        GetLocal,
+        SetLocal,
         /**
          * @brief Get value of the nth element of an array
          */
@@ -51,8 +53,10 @@ namespace GobLang
         OperationData{.op = Operation::Add, .text = "add", .argCount = 0},
         OperationData{.op = Operation::Sub, .text = "sub", .argCount = 0},
         OperationData{.op = Operation::Call, .text = "call", .argCount = 0},
-        OperationData{.op = Operation::Set, .text = "setvar", .argCount = 0},
-        OperationData{.op = Operation::Get, .text = "getvar", .argCount = 0},
+        OperationData{.op = Operation::Set, .text = "set_global", .argCount = 0},
+        OperationData{.op = Operation::Get, .text = "get_global", .argCount = 0},
+        OperationData{.op = Operation::SetLocal, .text = "set", .argCount = 1},
+        OperationData{.op = Operation::GetLocal, .text = "get", .argCount = 1},
         OperationData{.op = Operation::SetArray, .text = "set_arr", .argCount = 0},
         OperationData{.op = Operation::GetArray, .text = "get_arr", .argCount = 0},
         OperationData{.op = Operation::PushConstInt, .text = "push_int", .argCount = 1},
@@ -62,5 +66,6 @@ namespace GobLang
         OperationData{.op = Operation::Equals, .text = "eq", .argCount = 0},
         OperationData{.op = Operation::Jump, .text = "goto", .argCount = sizeof(size_t)},
         OperationData{.op = Operation::JumpIfNot, .text = "goto_if_not", .argCount = sizeof(size_t)},
-        OperationData{.op = Operation::End, .text = "hlt", .argCount = 0}};
+        OperationData{.op = Operation::End, .text = "hlt", .argCount = 0},
+    };
 } // namespace SimpleLang

--- a/execution/Value.cpp
+++ b/execution/Value.cpp
@@ -1,6 +1,6 @@
 #include "Value.hpp"
 #include "Memory.hpp"
-
+#include <iostream>
 bool GobLang::areEqual(MemoryValue const &a, MemoryValue const &b)
 {
     if (a.type != b.type)
@@ -26,4 +26,27 @@ bool GobLang::areEqual(MemoryValue const &a, MemoryValue const &b)
         return false;
     }
     return false;
+}
+
+std::string GobLang::valueToString(MemoryValue const &val)
+{
+    switch (val.type)
+    {
+    case Type::Null:
+        return "null";
+    case Type::Bool:
+        return std::get<bool>(val.value) ? "true" : "false";
+    case Type::Number:
+        return std::to_string(std::get<float>(val.value));
+    case Type::Int:
+        return std::to_string(std::get<int32_t>(val.value));
+    case Type::UserData:
+        return std::to_string((const size_t)std::get<void *>(val.value));
+    case Type::MemoryObj:
+        return std::get<MemoryNode *>(val.value)->toString();
+    case Type::NativeFunction:
+        // c++ has no equality check for std::function
+        return "Native function";
+    }
+    return "Invalid datatype";
 }

--- a/execution/Value.hpp
+++ b/execution/Value.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <variant>
+#include <string>
 #include "Type.hpp"
 
 namespace GobLang
@@ -27,4 +28,12 @@ namespace GobLang
      * @return false 
      */
     bool areEqual(MemoryValue const& a, MemoryValue const & b);
+
+    /**
+     * @brief Create a string representation of a given value
+     * 
+     * @param val 
+     * @return std::string 
+     */
+    std::string valueToString(MemoryValue const& val);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -28,32 +28,9 @@ void runParsing(std::string const &code)
 }
 int main(int, char **)
 {
-    std::string code1 = "if(a){print();} if(a){print();} else {if(b){print(40);}}";
+    std::string code1 = "let a = 90; let b = 90; let c = a + b; if(a == b){ let d = c;} else {let h = a;} i = a";
     std::string code2 = "if(a){print();} else {print();} if(a){print();} elif(b){print(40);} elif(b){print(40);} else {print();}";
-    // runParsing(code1);
+    runParsing(code1);
     // runParsing(code2);
-
-    std::vector<uint8_t> bytes;
-    size_t addr = 0x5f7d1f48;
-    for (int32_t i = sizeof(size_t) - 1; i >= 0; i--)
-    {
-        size_t offset = (sizeof(uint8_t) * i) * 8;
-        const size_t mask = 0xff;
-        size_t num = addr & (mask << offset);
-        size_t numFixed = num >> offset;
-
-        bytes.push_back(numFixed);
-    }
-    size_t reconAddr = 0x0;
-    for (int32_t i = 0; i < sizeof(size_t); i++)
-    {
-        size_t offset = ((sizeof(size_t) - i - 1)) * 8;
-        reconAddr |= (size_t)(bytes[i]) << offset;
-    }
-    std::cout << std::hex << reconAddr << std::endl;
-    for (auto it = bytes.begin(); it != bytes.end(); it++)
-    {
-        std::cout << std::hex << (size_t)(*it) << std::endl;
-    }
     return EXIT_SUCCESS;
 }

--- a/standard/MachineFunctions.cpp
+++ b/standard/MachineFunctions.cpp
@@ -9,30 +9,7 @@ void MachineFunctions::printLine(GobLang::Machine *machine)
     {
         return;
     }
-    switch (v->type)
-    {
-    case GobLang::Type::Null:
-        std::cout << "null" << std::endl;
-        break;
-    case GobLang::Type::Number:
-        std::cout << std::get<float>(v->value) << std::endl;
-        break;
-    case GobLang::Type::Bool:
-        std::cout << (std::get<bool>(v->value) ? "true" : "false") << std::endl;
-        break;
-    case GobLang::Type::Int:
-        std::cout << std::get<int32_t>(v->value) << std::endl;
-        break;
-    case GobLang::Type::UserData:
-        std::cerr << "Invalid data type" << std::endl;
-        break;
-    case GobLang::Type::MemoryObj:
-        std::cerr << std::get<GobLang::MemoryNode *>(v->value)->toString() << std::endl;
-        break;
-    case GobLang::Type::NativeFunction:
-        std::cerr << "Native function: " << &std::get<GobLang::FunctionValue>(v->value) << std::endl;
-        break;
-    }
+    std::cout << GobLang::valueToString(*v) << std::endl;
     delete v;
 }
 


### PR DESCRIPTION
Variables use indexing instead of strings and can only be utilized in the block that they were defined in