### PR TITLE
Add support for unary operations

### DIFF
--- a/compiler.cpp
+++ b/compiler.cpp
@@ -78,8 +78,8 @@ int main()
     GobLang::Compiler::Parser comp("a =- 3; print(a);");
     comp.parse();
     comp.printCode();
-    // GobLang::Compiler::Validator validator(comp);
-    // validator.validate();
+    GobLang::Compiler::Validator validator(comp);
+    validator.validate();
     GobLang::Compiler::Compiler compiler(comp);
     compiler.compile();
     compiler.printCode();

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -61,21 +61,24 @@ void byteCodeToText(std::vector<uint8_t> const &bytecode)
 }
 int main()
 {
-    // std::string file = "./code.gob";
-    // std::vector<std::string> lines;
-    // std::ifstream codeFile(file);
-    // if (!codeFile.is_open())
-    // {
-    //     std::cerr << "Unable to open code file" << std::endl;
-    //     return EXIT_FAILURE;
-    // }
-    // std::string to;
-    // while (std::getline(codeFile, to, '\n'))
-    // {
-    //     lines.push_back(to);
-    // }
+    std::string file = "./code.gob";
+    std::vector<std::string> lines;
+    std::ifstream codeFile(file);
+    if (!codeFile.is_open())
+    {
+        std::cerr << "Unable to open code file" << std::endl;
+        return EXIT_FAILURE;
+    }
+    std::string to;
+    while (std::getline(codeFile, to, '\n'))
+    {
+        lines.push_back(to);
+    }
 
-    GobLang::Compiler::Parser comp("a =- 3; print(a);");
+    GobLang::Compiler::Parser comp(lines);
+    int a = 3;
+    bool b = !(a < 3 || (a > 1 && !(a < 1)));
+    std::cout << (b ? "true" : "false") << std::endl;
     comp.parse();
     comp.printCode();
     GobLang::Compiler::Validator validator(comp);
@@ -90,12 +93,12 @@ int main()
     machine.addFunction(MachineFunctions::getSizeof, "sizeof");
     machine.addFunction(MachineFunctions::printLine, "print");
     machine.addFunction(MachineFunctions::createArrayOfSize, "array");
-    std::vector<size_t> debugPoints = {};
+    std::vector<size_t> debugPoints = { 0x42, 0x44,0x46,0x47};
     while (!machine.isAtTheEnd())
     {
         if (std::find(debugPoints.begin(), debugPoints.end(), machine.getProgramCounter()) != debugPoints.end())
         {
-            std::cout << "Debugging at " << std::hex << machine.getProgramCounter() << std::dec << std::endl;
+            std::cout << "Debugging at " << std::hex << machine.getProgramCounter() << std::dec << ". Memory state: " << std::endl;
             machine.printGlobalsInfo();
             machine.printVariablesInfo();
             machine.printStack();

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -61,24 +61,25 @@ void byteCodeToText(std::vector<uint8_t> const &bytecode)
 }
 int main()
 {
-    std::string file = "./code.gob";
-    std::vector<std::string> lines;
-    std::ifstream codeFile(file);
-    if (!codeFile.is_open())
-    {
-        std::cerr << "Unable to open code file" << std::endl;
-        return EXIT_FAILURE;
-    }
-    std::string to;
-    while (std::getline(codeFile, to, '\n'))
-    {
-        lines.push_back(to);
-    }
+    // std::string file = "./code.gob";
+    // std::vector<std::string> lines;
+    // std::ifstream codeFile(file);
+    // if (!codeFile.is_open())
+    // {
+    //     std::cerr << "Unable to open code file" << std::endl;
+    //     return EXIT_FAILURE;
+    // }
+    // std::string to;
+    // while (std::getline(codeFile, to, '\n'))
+    // {
+    //     lines.push_back(to);
+    // }
 
-    GobLang::Compiler::Parser comp(lines);
+    GobLang::Compiler::Parser comp("a =- 3; print(a);");
     comp.parse();
-    GobLang::Compiler::Validator validator(comp);
-    validator.validate();
+    comp.printCode();
+    // GobLang::Compiler::Validator validator(comp);
+    // validator.validate();
     GobLang::Compiler::Compiler compiler(comp);
     compiler.compile();
     compiler.printCode();

--- a/compiler/Compiler.cpp
+++ b/compiler/Compiler.cpp
@@ -598,7 +598,6 @@ void GobLang::Compiler::Compiler::_compileSeparators(SeparatorToken *sepToken, s
             {
                 whileToken->setReturnMark(getMarkCounterAndAdvance());
                 GotoToken *loopJump = new GotoToken(sepToken->getRow(), sepToken->getColumn(), whileToken->getReturnMark());
-                m_jumps.push_back(loopJump);
                 m_compilerTokens.push_back(loopJump);
                 m_code.push_back(loopJump);
             }

--- a/compiler/Compiler.hpp
+++ b/compiler/Compiler.hpp
@@ -100,6 +100,17 @@ namespace GobLang::Compiler
         void _printTokenStack();
 
         bool _isBranchKeyword(std::vector<Token *>::const_iterator const& it);
+
+        void _addOperator(std::vector<Token *>::const_iterator const& it);
+
+        /**
+         * @brief Check if this is valid binary operation
+         * 
+         * @param it Iterator pointing to current operation token
+         * @return true This operator can be considered binary operator
+         * @return false This  operator is most likey an unary operator
+         */
+        bool _isValidBinaryOperation(std::vector<Token *>::const_iterator const& it);
         /**
          * @brief code representation in reverse polish notation
          *

--- a/compiler/Lexems.hpp
+++ b/compiler/Lexems.hpp
@@ -109,7 +109,7 @@ namespace GobLang::Compiler
         OperatorData{.symbol = "-", .op = Operator::Sub, .priority = 6, .operation = Operation::Sub},
         OperatorData{.symbol = "*", .op = Operator::Mul, .priority = 7, .operation = Operation::None},
         OperatorData{.symbol = "/", .op = Operator::Div, .priority = 7, .operation = Operation::None},
-        OperatorData{.symbol = "and", .op = Operator::And, .priority = 4, .operation = Operation::Add},
+        OperatorData{.symbol = "and", .op = Operator::And, .priority = 4, .operation = Operation::And},
         OperatorData{.symbol = "&&", .op = Operator::And, .priority = 4, .operation = Operation::And},
         OperatorData{.symbol = "or", .op = Operator::Or, .priority = 3, .operation = Operation::Or},
         OperatorData{.symbol = "||", .op = Operator::Or, .priority = 3, .operation = Operation::Or}};

--- a/compiler/Lexems.hpp
+++ b/compiler/Lexems.hpp
@@ -91,7 +91,7 @@ namespace GobLang::Compiler
         {"false", false},
         {"True", true},
         {"False", false}};
-        
+
     /**
      * @brief Static array containing info about all operators used in the compiler
      *
@@ -101,8 +101,8 @@ namespace GobLang::Compiler
         OperatorData{.symbol = ">=", .op = Operator::LessEq, .priority = 5, .operation = Operation::MoreOrEq},
         OperatorData{.symbol = "<=", .op = Operator::MoreEq, .priority = 5, .operation = Operation::LessOrEq},
         OperatorData{.symbol = "=", .op = Operator::Assign, .priority = 1, .operation = Operation::Set},
-        OperatorData{.symbol = "!", .op = Operator::Not, .priority = 5, .operation = Operation::Not},
         OperatorData{.symbol = "!=", .op = Operator::NotEqual, .priority = 5, .operation = Operation::NotEq},
+        OperatorData{.symbol = "!", .op = Operator::Not, .priority = 5, .operation = Operation::Not},
         OperatorData{.symbol = "<", .op = Operator::Less, .priority = 5, .operation = Operation::Less},
         OperatorData{.symbol = ">", .op = Operator::More, .priority = 5, .operation = Operation::More},
         OperatorData{.symbol = "+", .op = Operator::Add, .priority = 6, .operation = Operation::Add},

--- a/compiler/Token.cpp
+++ b/compiler/Token.cpp
@@ -26,6 +26,21 @@ GobLang::Compiler::OperatorToken::OperatorToken(size_t row, size_t column, Opera
                              { return op.op == oper; }));
 }
 
+GobLang::Operation GobLang::Compiler::OperatorToken::getOperation() const
+{
+    if (!isUnary())
+    {
+        return m_data->operation;
+    }
+    switch (getOperator())
+    {
+    case Operator::Sub:
+        return Operation::Negate;
+    default:
+        return m_data->operation;
+    }
+}
+
 int32_t GobLang::Compiler::OperatorToken::getPriority() const
 {
     return m_data->priority;
@@ -33,7 +48,7 @@ int32_t GobLang::Compiler::OperatorToken::getPriority() const
 
 std::string GobLang::Compiler::OperatorToken::toString()
 {
-    return m_data->symbol;
+    return std::string(m_data->symbol) + (m_unary ? "u" : "");
 }
 
 std::string GobLang::Compiler::IdToken::toString()
@@ -80,4 +95,9 @@ std::string GobLang::Compiler::JumpDestinationToken::toString()
 std::string GobLang::Compiler::WhileToken::toString()
 {
     return "WHILE_M" + std::to_string(m_returnMark) + "_THEN_M" + std::to_string(getMark());
+}
+
+std::string GobLang::Compiler::FloatToken::toString()
+{
+    return "FLOAT" + std::to_string(m_id);
 }

--- a/compiler/Token.hpp
+++ b/compiler/Token.hpp
@@ -41,12 +41,16 @@ namespace GobLang::Compiler
     public:
         explicit OperatorToken(size_t row, size_t column, Operator oper);
         Operator getOperator() const { return m_data->op; }
-        Operation getOperation() const { return m_data->operation; }
+        Operation getOperation() const;
         virtual int32_t getPriority() const override;
         std::string toString() override;
 
+        bool isUnary() const { return m_unary; }
+        void setIsUnary(bool unary) { m_unary = unary; }
+
     private:
         OperatorData const *m_data;
+        bool m_unary;
     };
 
     class IdToken : public Token
@@ -94,6 +98,18 @@ namespace GobLang::Compiler
     {
     public:
         explicit IntToken(size_t row, size_t column, size_t id) : Token(row, column), m_id(id) {}
+        std::string toString() override;
+
+        size_t getId() const { return m_id; }
+
+    private:
+        size_t m_id;
+    };
+
+    class FloatToken : public Token
+    {
+    public:
+        explicit FloatToken(size_t row, size_t column, size_t id) : Token(row, column), m_id(id) {}
         std::string toString() override;
 
         size_t getId() const { return m_id; }

--- a/compiler/Validator.hpp
+++ b/compiler/Validator.hpp
@@ -22,6 +22,7 @@ namespace GobLang::Compiler
 
         bool constant(TokenIterator const &it);
         bool id(TokenIterator const &it);
+        bool unaryOperator(TokenIterator const& it);
         bool mathOperator(TokenIterator const &it);
         bool actionOperator(TokenIterator const &it, Operator op);
         bool separator(TokenIterator const &it, Separator sep);
@@ -29,17 +30,33 @@ namespace GobLang::Compiler
         bool end(TokenIterator const &it);
         bool operand(TokenIterator const &it);
 
-        bool expr(TokenIterator const &it, TokenIterator &endIt);
-        bool mul(TokenIterator const &it, TokenIterator &endIt);
         /**
-         * @brief Expression between '(' and ')'
-         *
-         * @param it
-         * @param endIt
-         * @return true
-         * @return false
+         * @brief Repeating rule for expr = mul {op mul}
+         * 
+         * @param it 
+         * @param endIt 
+         * @return true 
+         * @return false 
          */
-        bool groupedExpr(TokenIterator const &it, TokenIterator &endIt);
+        bool expr(TokenIterator const &it, TokenIterator &endIt);
+        /**
+         * @brief Expressions which only use one operand. "!a" and "-a"
+         * 
+         * @param it 
+         * @param endIt 
+         * @return true 
+         * @return false 
+         */
+        bool unaryExpr(TokenIterator const& it, TokenIterator &endIt);
+        /**
+         * @brief Check that covers anything that follows this rule expr = arrayAccess | call | operand | (expr) 
+         * 
+         * @param it 
+         * @param endIt 
+         * @return true 
+         * @return false 
+         */
+        bool mul(TokenIterator const &it, TokenIterator &endIt);
         bool functionCall(TokenIterator const &it, TokenIterator &endIt);
         bool arrayAccess(TokenIterator const &it, TokenIterator &endIt);
         bool call(TokenIterator const &it, TokenIterator &endIt);

--- a/execution/Machine.cpp
+++ b/execution/Machine.cpp
@@ -80,11 +80,17 @@ void GobLang::Machine::step()
     case Operation::More:
         _more();
         break;
+    case Operation::Not:
+        _not();
+        break;
     case Operation::LessOrEq:
         _lessOrEq();
         break;
     case Operation::MoreOrEq:
         _moreOrEq();
+        break;
+    case Operation::Negate:
+        _negate();
         break;
     case Operation::End:
         m_forcedEnd = true;
@@ -529,6 +535,34 @@ void GobLang::Machine::_moreOrEq()
             throw RuntimeException(std::string("Attempted to compare value of type ") + typeToString(a.type) + ". Only numeric types can be compared using >,<, <=, >=");
         }
     }
+}
+
+void GobLang::Machine::_negate()
+{
+    MemoryValue val = *m_operationStack.rbegin();
+    m_operationStack.pop_back();
+    switch (val.type)
+    {
+    case Type::Int:
+        m_operationStack.push_back(MemoryValue{.type = Type::Int, .value = -std::get<int32_t>(val.value)});
+        break;
+    case Type::Number:
+        m_operationStack.push_back(MemoryValue{.type = Type::Number, .value = -std::get<float>(val.value)});
+        break;
+    default:
+        throw RuntimeException("Attempted to apply negate operation on a non numeric value");
+    }
+}
+
+void GobLang::Machine::_not()
+{
+    MemoryValue val = *m_operationStack.rbegin();
+    m_operationStack.pop_back();
+    if (val.type != Type::Bool)
+    {
+        throw RuntimeException("Attempted to negate non boolean value");
+    }
+    m_operationStack.push_back(MemoryValue{.type = Type::Bool, .value = !std::get<bool>(val.value)});
 }
 
 const char *GobLang::RuntimeException::what() const throw()

--- a/execution/Machine.hpp
+++ b/execution/Machine.hpp
@@ -151,6 +151,10 @@ namespace GobLang
 
         void _moreOrEq();
 
+        void _negate();
+
+        void _not();
+
         bool m_forcedEnd = false;
 
         MemoryNode *m_memoryRoot = new MemoryNode();

--- a/execution/Machine.hpp
+++ b/execution/Machine.hpp
@@ -142,6 +142,10 @@ namespace GobLang
         void _eq();
 
         void _neq();
+        
+        void _and();
+        
+        void _or();
 
         void _less();
 

--- a/execution/Operations.hpp
+++ b/execution/Operations.hpp
@@ -36,6 +36,7 @@ namespace GobLang
         And,
         Or,
         Not,
+        Negate,
         /**
          * @brief Unconditionally jump. Uses sizeof(size_t) bytes to get the address to jump to
          */
@@ -75,6 +76,8 @@ namespace GobLang
         OperationData{.op = Operation::PushFalse, .text = "push_false", .argCount = 0},
         OperationData{.op = Operation::Equals, .text = "eq", .argCount = 0},
         OperationData{.op = Operation::NotEq, .text = "neq", .argCount = 0},
+        OperationData{.op = Operation::Not, .text = "not", .argCount = 0},
+        OperationData{.op = Operation::Negate, .text = "negate", .argCount = 0},
         OperationData{.op = Operation::More, .text = "more", .argCount = 0},
         OperationData{.op = Operation::Less, .text = "less", .argCount = 0},
         OperationData{.op = Operation::MoreOrEq, .text = "eqmore", .argCount = 0},

--- a/execution/Type.cpp
+++ b/execution/Type.cpp
@@ -6,6 +6,8 @@ const char *GobLang::typeToString(Type type)
     {
     case Type::Null:
         return "Null";
+    case Type::Bool:
+        return "Bool";
     case Type::Number:
         return "Float";
     case Type::Int:

--- a/standard/MachineFunctions.hpp
+++ b/standard/MachineFunctions.hpp
@@ -10,4 +10,8 @@ namespace MachineFunctions
     void createArrayOfSize(GobLang::Machine *machine);
 
     void getSizeof(GobLang::Machine * machine);
+
+    void input(GobLang::Machine * machine);
+
+    void toInt(GobLang::Machine * machine);
 }

--- a/test.cpp
+++ b/test.cpp
@@ -115,25 +115,30 @@ void testBlockArray()
     Validator::TokenIterator endIt;
     assert(v.block(p.getTokens().begin(), endIt));
 }
-int main(int, char **)
-{
-    // testArray();
-    // testArray2();
-    // testArray2D();
-    // testArrayUse();
-    // testArrayAssign();
-    // testArrayAssign2D();
-    // testBlock();
-    // testCall();
-    // testCallArg();
-    // testCallArgs();
-    // testBlockArray();
 
-    Parser p("let a = 3;print(a);if");
+void testUnary()
+{
+    Parser p("!a");
     p.parse();
     p.printCode();
     Validator v(p);
-    v.validate();
+    Validator::TokenIterator endIt;
+    assert(v.unaryExpr(p.getTokens().begin(), endIt));
+}
+int main(int, char **)
+{
+    testArray();
+    testArray2();
+    testArray2D();
+    testArrayUse();
+    testArrayAssign();
+    testArrayAssign2D();
+    testBlock();
+    testCall();
+    testCallArg();
+    testCallArgs();
+    testBlockArray();
+    testUnary();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This closes #4 by adding parsing, validation and execution logic for the unary operations of `!a` and `-a`
This also fixes:
*  a bug with loop nesting where jump was incorrectly discarded
* a bug where local variable array was resized based on current id without proper checks so it would shrink discarding existing values if id was lower than current active size
