### PR TITLE
Add a very basic garbage collector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(goblang VERSION 0.1.0 LANGUAGES C CXX)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 add_compile_definitions(GOB_LANG_VERSION_MAJOR=0)
-add_compile_definitions(GOB_LANG_VERSION_MINOR=1)
+add_compile_definitions(GOB_LANG_VERSION_MINOR=2)
 
 add_compile_definitions(LINES_BEFORE_ERROR=3)
 add_compile_definitions(LINES_AFTER_ERROR=3)

--- a/compiler.cpp
+++ b/compiler.cpp
@@ -91,7 +91,8 @@ int main()
 
     GobLang::Machine machine(compiler.getByteCode());
     machine.addFunction(MachineFunctions::getSizeof, "sizeof");
-    machine.addFunction(MachineFunctions::printLine, "print");
+    machine.addFunction(MachineFunctions::printLine, "print_line");
+    machine.addFunction(MachineFunctions::print, "print");
     machine.addFunction(MachineFunctions::createArrayOfSize, "array");
     machine.addFunction(MachineFunctions::input, "input");
     machine.addFunction(MachineFunctions::Math::toInt, "to_int");

--- a/compiler/Compiler.cpp
+++ b/compiler/Compiler.cpp
@@ -582,7 +582,10 @@ void GobLang::Compiler::Compiler::_compileSeparators(SeparatorToken *sepToken, s
         break;
     case Separator::BlockClose:
         dumpStack();
-        m_code.push_back(new LocalVarShrinkToken(sepToken->getRow(), sepToken->getColumn(), m_blockVariables.rbegin()->size()));
+        if (m_blockVariables.rbegin()->size() > 0)
+        {
+            m_code.push_back(new LocalVarShrinkToken(sepToken->getRow(), sepToken->getColumn(), m_blockVariables.rbegin()->size()));
+        }
         _popVariableBlock();
         if (!m_jumps.empty())
         {

--- a/compiler/Compiler.cpp
+++ b/compiler/Compiler.cpp
@@ -242,6 +242,11 @@ void GobLang::Compiler::Compiler::generateByteCode()
 
             stack.push_back(new ArrayCompilerNode(array, index, isDestination, destMark));
         }
+        else if (LocalVarShrinkToken *shrinkTok = dynamic_cast<LocalVarShrinkToken *>(*it); shrinkTok != nullptr)
+        {
+            m_byteCode.operations.push_back((uint8_t)Operation::ShrinkLocal);
+            m_byteCode.operations.push_back((uint8_t)shrinkTok->getAmount());
+        }
     }
     for (std::vector<CompilerNode *>::iterator it = stack.begin(); it != stack.end(); it++)
     {
@@ -576,8 +581,9 @@ void GobLang::Compiler::Compiler::_compileSeparators(SeparatorToken *sepToken, s
         _appendVariableBlock();
         break;
     case Separator::BlockClose:
-        _popVariableBlock();
         dumpStack();
+        m_code.push_back(new LocalVarShrinkToken(sepToken->getRow(), sepToken->getColumn(), m_blockVariables.rbegin()->size()));
+        _popVariableBlock();
         if (!m_jumps.empty())
         {
             GotoToken *jump = *m_jumps.rbegin();
@@ -595,7 +601,7 @@ void GobLang::Compiler::Compiler::_compileSeparators(SeparatorToken *sepToken, s
                 m_compilerTokens.push_back(dest);
                 m_code.push_back(dest);
             }
-            
+
             else if (WhileToken *whileToken = dynamic_cast<WhileToken *>(jump); whileToken != nullptr)
             {
                 whileToken->setReturnMark(getMarkCounterAndAdvance());
@@ -759,6 +765,6 @@ bool GobLang::Compiler::Compiler::_isValidBinaryOperation(std::vector<Token *>::
            dynamic_cast<IntToken *>(*prevIt) ||
            dynamic_cast<FloatToken *>(*prevIt) ||
            dynamic_cast<CharToken *>(*prevIt) ||
-            dynamic_cast<StringToken *>(*prevIt)||
+           dynamic_cast<StringToken *>(*prevIt) ||
            dynamic_cast<BoolConstToken *>(*prevIt);
 }

--- a/compiler/CompilerToken.cpp
+++ b/compiler/CompilerToken.cpp
@@ -4,3 +4,8 @@ void GobLang::Compiler::FunctionCallToken::increaseArgCount()
 {
     m_argCount++;
 }
+
+std::string GobLang::Compiler::LocalVarShrinkToken::toString()
+{
+    return "SHRINK_BY" + std::to_string(m_amount);
+}

--- a/compiler/CompilerToken.hpp
+++ b/compiler/CompilerToken.hpp
@@ -50,4 +50,15 @@ namespace GobLang::Compiler
     private:
         size_t m_varId;
     };
+
+    class LocalVarShrinkToken : public Token
+    {
+    public:
+        explicit LocalVarShrinkToken(size_t row, size_t column, size_t amount) : Token(row, column), m_amount(amount) {}
+        size_t getAmount() const { return m_amount; }
+
+        std::string toString() override;
+    private:
+        size_t m_amount;
+    };
 }

--- a/execution/Array.hpp
+++ b/execution/Array.hpp
@@ -16,6 +16,8 @@ namespace GobLang
 
         size_t getSize() const { return m_data.size(); }
 
+        virtual ~ArrayNode();
+
     private:
         std::vector<MemoryValue> m_data;
     };

--- a/execution/Machine.cpp
+++ b/execution/Machine.cpp
@@ -235,11 +235,12 @@ GobLang::MemoryValue *GobLang::Machine::getLocalVariableValue(size_t id)
 
 void GobLang::Machine::shrinkLocalVariableStackBy(size_t size)
 {
-    for (int32_t i = m_variables.size() - 1; i >= m_variables.size() - size; i--)
+    for (size_t i = 0; i < size; i++)
     {
-        if (m_variables[i].type == Type::MemoryObj)
+        size_t ind = m_variables.size() - i - 1;
+        if (m_variables[ind].type == Type::MemoryObj)
         {
-            std::get<MemoryNode *>(m_variables[i].value)->decreaseRefCount();
+            std::get<MemoryNode *>(m_variables[ind].value)->decreaseRefCount();
         }
     }
     // possibly add m_variables.resize(m_variables.size() - size)

--- a/execution/Machine.cpp
+++ b/execution/Machine.cpp
@@ -31,6 +31,7 @@ void GobLang::Machine::step()
         break;
     case Operation::Set:
         _set();
+        collectGarbage();
         break;
     case Operation::Get:
         _get();
@@ -40,6 +41,7 @@ void GobLang::Machine::step()
         break;
     case Operation::SetLocal:
         _setLocal();
+        collectGarbage();
         break;
     case Operation::PushConstInt:
         _pushConstInt();
@@ -55,6 +57,7 @@ void GobLang::Machine::step()
         break;
     case Operation::SetArray:
         _setArray();
+        collectGarbage();
         break;
     case Operation::Jump:
         _jump();
@@ -97,6 +100,10 @@ void GobLang::Machine::step()
         break;
     case Operation::Negate:
         _negate();
+        break;
+    case Operation::ShrinkLocal:
+        _shrink();
+        collectGarbage();
         break;
     case Operation::End:
         m_forcedEnd = true;
@@ -164,7 +171,7 @@ GobLang::MemoryValue *GobLang::Machine::getStackTopAndPop()
 GobLang::ArrayNode *GobLang::Machine::createArrayOfSize(int32_t size)
 {
     ArrayNode *node = new ArrayNode(size);
-    m_memoryRoot->push_back(node);
+    m_memoryRoot->pushBack(node);
     return node;
 }
 
@@ -185,7 +192,7 @@ GobLang::StringNode *GobLang::Machine::createString(std::string const &str, bool
     if (node == nullptr)
     {
         node = new StringNode(str);
-        m_memoryRoot->push_back(node);
+        m_memoryRoot->pushBack(node);
     }
     return node;
 }
@@ -206,6 +213,14 @@ void GobLang::Machine::setLocalVariableValue(size_t id, MemoryValue const &val)
     {
         m_variables.resize(id + 1);
     }
+    if (val.type == Type::MemoryObj)
+    {
+        std::get<MemoryNode *>(val.value)->increaseRefCount();
+    }
+    if (m_variables[id].type == Type::MemoryObj)
+    {
+        std::get<MemoryNode *>(m_variables[id].value)->decreaseRefCount();
+    }
     m_variables[id] = val;
 }
 
@@ -218,9 +233,55 @@ GobLang::MemoryValue *GobLang::Machine::getLocalVariableValue(size_t id)
     return &m_variables[id];
 }
 
+void GobLang::Machine::shrinkLocalVariableStackBy(size_t size)
+{
+    for (int32_t i = m_variables.size() - 1; i >= m_variables.size() - size; i--)
+    {
+        if (m_variables[i].type == Type::MemoryObj)
+        {
+            std::get<MemoryNode *>(m_variables[i].value)->decreaseRefCount();
+        }
+    }
+    // possibly add m_variables.resize(m_variables.size() - size)
+}
+
 void GobLang::Machine::createVariable(std::string const &name, MemoryValue const &value)
 {
     m_globals[name] = value;
+}
+
+void GobLang::Machine::collectGarbage()
+{
+    MemoryNode *prev = m_memoryRoot;
+    MemoryNode *curr = m_memoryRoot->getNext();
+    while (curr != nullptr)
+    {
+        if (!curr->isDead())
+        {
+            prev = curr;
+            curr = curr->getNext();
+            continue;
+        }
+        // if we are deleting then prev should stay the same while
+        // curr gets deleted
+        MemoryNode *del = curr;
+        prev->eraseNext();
+        curr = prev->getNext();
+
+        delete del;
+    }
+}
+
+GobLang::Machine::~Machine()
+{
+    MemoryNode *root = m_memoryRoot->getNext();
+    while (root != nullptr)
+    {
+        MemoryNode *del = root;
+        root = root->getNext();
+        delete del;
+    }
+    delete m_memoryRoot;
 }
 
 GobLang::ProgramAddressType GobLang::Machine::_getAddressFromByteCode(size_t start)
@@ -292,6 +353,14 @@ void GobLang::Machine::_set()
     StringNode *memStr = dynamic_cast<StringNode *>(std::get<MemoryNode *>(name.value));
     if (memStr != nullptr)
     {
+        if (val.type == Type::MemoryObj)
+        {
+            std::get<MemoryNode *>(val.value)->increaseRefCount();
+        }
+        if (m_globals.count(memStr->getString()) > 0 && m_globals[memStr->getString()].type == Type::MemoryObj)
+        {
+            std::get<MemoryNode *>(m_globals[memStr->getString()].value)->decreaseRefCount();
+        }
         m_globals[memStr->getString()] = val;
     }
 }
@@ -617,4 +686,11 @@ void GobLang::Machine::_not()
         throw RuntimeException("Attempted to negate non boolean value");
     }
     m_operationStack.push_back(MemoryValue{.type = Type::Bool, .value = !std::get<bool>(val.value)});
+}
+
+void GobLang::Machine::_shrink()
+{
+    m_programCounter++;
+    size_t amount = (size_t)m_operations[m_programCounter];
+    shrinkLocalVariableStackBy(amount);
 }

--- a/execution/Machine.hpp
+++ b/execution/Machine.hpp
@@ -106,6 +106,8 @@ namespace GobLang
          */
         MemoryValue *getLocalVariableValue(size_t id);
 
+        void shrinkLocalVariableStackBy(size_t size);
+
         /**
          * @brief Create a custom variable that will be accessible in code. Useful for binding with c code
          *
@@ -114,10 +116,9 @@ namespace GobLang
          */
         void createVariable(std::string const &name, MemoryValue const &value);
 
-        ~Machine()
-        {
-            delete m_memoryRoot;
-        }
+        void collectGarbage();
+
+        ~Machine();
 
     private:
         ProgramAddressType _getAddressFromByteCode(size_t start);
@@ -169,6 +170,8 @@ namespace GobLang
         void _negate();
 
         void _not();
+
+        void _shrink();
 
         bool m_forcedEnd = false;
 

--- a/execution/Memory.cpp
+++ b/execution/Memory.cpp
@@ -9,14 +9,48 @@ void GobLang::MemoryNode::insert(MemoryNode *node)
     }
 }
 
-void GobLang::MemoryNode::push_back(MemoryNode *node)
+void GobLang::MemoryNode::eraseNext()
 {
+    if (m_next != nullptr)
+    {
+        m_next = m_next->m_next;
+    }
+}
+
+void GobLang::MemoryNode::pushBack(MemoryNode *node)
+{
+    if (node == nullptr)
+    {
+        // don't pollute the memory
+        return;
+    }
     MemoryNode *curr = this;
     while (curr->m_next != nullptr)
     {
         curr = curr->m_next;
     }
     curr->m_next = node;
+}
+
+void GobLang::MemoryNode::increaseRefCount()
+{
+    m_refCount++;
+}
+
+void GobLang::MemoryNode::decreaseRefCount()
+{
+    m_refCount--;
+}
+
+size_t GobLang::MemoryNode::length()
+{
+    MemoryNode *curr = this->m_next;
+    size_t size = 1;
+    for (; curr != nullptr; curr = curr->m_next)
+    {
+        size++;
+    }
+    return size;
 }
 
 bool GobLang::MemoryNode::equalsTo(MemoryNode *other)
@@ -36,7 +70,7 @@ void GobLang::StringNode::setCharAt(char ch, size_t ind)
 
 bool GobLang::StringNode::equalsTo(MemoryNode *other)
 {
-    if(StringNode* otherStr = dynamic_cast<StringNode*>(other); otherStr != nullptr)
+    if (StringNode *otherStr = dynamic_cast<StringNode *>(other); otherStr != nullptr)
     {
         return otherStr->getString() == getString();
     }

--- a/execution/Memory.hpp
+++ b/execution/Memory.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
+#include <iostream>
 #include "Type.hpp"
 namespace GobLang
 {
@@ -17,7 +18,7 @@ namespace GobLang
          * @return true
          * @return false
          */
-        bool isDead() const { return m_dead; }
+        bool isDead() const { return m_dead || m_refCount <= 0; }
         /**
          * @brief Get the next node in the list
          *
@@ -32,11 +33,30 @@ namespace GobLang
         void insert(MemoryNode *node);
 
         /**
+         * @brief Erase current m_next by replacing it with the child of that object. Does not call any memory freeing functions
+         *
+         */
+        void eraseNext();
+
+        /**
          * @brief Insert a node at the end of the chain
          *
          * @param node Node to insert
          */
-        void push_back(MemoryNode *node);
+        void pushBack(MemoryNode *node);
+
+        void increaseRefCount();
+
+        void decreaseRefCount();
+
+        int32_t getRefCount() const { return m_refCount; }
+
+        /**
+         * @brief Size of the memory chain
+         *
+         * @return size_t
+         */
+        size_t length();
 
         /**
          * @brief Check if this memory value is equal to other value. This should be overriden to have type specific to avoid java situation
@@ -62,6 +82,8 @@ namespace GobLang
          *
          */
         bool m_dead = false;
+
+        int32_t m_refCount = 0;
     };
 
     class StringNode : public MemoryNode

--- a/execution/Operations.hpp
+++ b/execution/Operations.hpp
@@ -46,6 +46,10 @@ namespace GobLang
          */
         JumpIfNot,
         /**
+         * @brief Shrink local variable array by n variables
+         */
+        ShrinkLocal,
+        /**
          * @brief End program execution
          */
         End
@@ -84,6 +88,7 @@ namespace GobLang
         OperationData{.op = Operation::LessOrEq, .text = "eqless", .argCount = 0},
         OperationData{.op = Operation::Jump, .text = "goto", .argCount = sizeof(size_t)},
         OperationData{.op = Operation::JumpIfNot, .text = "goto_if_not", .argCount = sizeof(size_t)},
+        OperationData{.op = Operation::ShrinkLocal, .text = "local_free", .argCount = 1},
         OperationData{.op = Operation::End, .text = "hlt", .argCount = 0},
     };
 } // namespace SimpleLang

--- a/readme.md
+++ b/readme.md
@@ -158,7 +158,14 @@ struct MemoryValue
 };
 ```
 
-# Using
+## Garbage collection
+
+There is a very basic garbage collector implemented into the interpreter that uses reference counting to know when to delete objects. 
+Every object is created with ref count being set to 0 and on every assignment operation(which includes operations like setting a global value, local value and array value) it increases the ref count by 1. On the same operations it checks if object that is being replaced by set operation is object and if so, decreases ref counter for that object.
+
+Similar operation occurs when shrinking the local variable array, although it only performs ref count decrease.
+
+# Using the interpreter
 
 To execute the code call `goblang -i <code_with_file>` in the terminal
 Options: 
@@ -198,12 +205,7 @@ impl Type{
     func method2() {}
 }
 ```
-## Garbage collection
 
-Currently there is no system for managing memory so anytime object is created it stays there forever.
-Some possible ideas:
- * A useful way to do this would be to add instructions which would hint interpreter that some local variables can be erased. 
- * Checking both global and local variable storage for references to any memory object, although this will require some form of cyclical reference check to avoid creating an infinite loop
 ## Strong typing
 
 While right now there are no 'compile' time type checks, i do want to add them to the project. As well as ability to disallow globals, requiring to tell the parser all functions in advance instead of assuming that they will be added after generating bytecode


### PR DESCRIPTION
This closes #9  by adding a very basic garbage collection system that relies on reference counting. Each memory object will have a ref counter which will increase when this object is assigned to any variable or array, and decreased when assignment replaces that object.

This also adds instructions that tell interpreter to shrink or expand local variable array, which also will trigger ref count changes and clean up. Although it is worth noting that variable array itself does not change in size to avoid constant resizing.
This system is very crude and potentially buggy however it does clean up memory as intended, cleaning up strings and arrays when they are no longer in use. The system is kinda aggressive trying to clean objects up at any opportunity so that could be made less aggressive 