### PR TITLE
Update user data system and add basic file io

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ list(APPEND COMMON_SOURCE_FILES execution/Type.hpp
 list(APPEND STD_SOURCE_FILES execution/Type.hpp
     standard/MachineFunctions.hpp
     standard/MachineFunctions.cpp
+    standard/File.hpp
+    standard/File.cpp
 )
 
 

--- a/compiler/Compiler.cpp
+++ b/compiler/Compiler.cpp
@@ -82,10 +82,6 @@ std::vector<uint8_t> GobLang::Compiler::Compiler::generateSetByteCode(Token *tok
 
 void GobLang::Compiler::Compiler::appendCompilerNode(CompilerNode *node, bool getter)
 {
-    if (node->hasMark())
-    {
-        m_jumpDestinations[node->getMark()] = m_byteCode.operations.size() - 1;
-    }
     std::vector<uint8_t> code = getter ? node->getOperationGetBytes() : node->getOperationSetBytes();
     m_byteCode.operations.insert(m_byteCode.operations.end(), code.begin(), code.end());
 }

--- a/examples/read_all_lines.gob
+++ b/examples/read_all_lines.gob
@@ -1,0 +1,22 @@
+func read_all_lines(file)
+{
+    let result = array(0);
+    while(!file_is_eof(file))
+    {
+        append(result, file_read_line(file));
+    }
+    return result;
+}
+
+
+file = file_open("./text.txt", true);
+if(!file_is_open(file)){
+    print_line("Unable to open file");
+}
+else{
+    print_line("File contents:" );
+    let lines = read_all_lines(file);
+    print_line("File lines: " + str(sizeof(lines)));
+    print_line(lines);
+    file_close(file);
+}

--- a/examples/read_and_write_to_file.gob
+++ b/examples/read_and_write_to_file.gob
@@ -1,0 +1,20 @@
+let file = file_open("./text.txt", false);
+if(!file_is_open(file)){
+    print_line("Unable to open file");
+}
+else{
+    file_write(file, "hello dingus");
+    file_close(file);
+}
+file = file_open("./text.txt", true);
+if(!file_is_open(file)){
+    print_line("Unable to open file");
+}
+else{
+    print_line("File contents:" );
+    while(!file_is_eof(file))
+    {
+        print_line(file_read_line(file));
+    }
+    file_close(file);
+}

--- a/examples/text.txt
+++ b/examples/text.txt
@@ -1,0 +1,8 @@
+Programming — composition of sequence of instructions,
+ called programs,
+  that computers can follow to perform tasks.
+These programs are used in a wide range of applications in nearly every field.  
+A large portion of programming is dedicated to writing and debugging  
+source code and majority of programming languages require writing code using text based format.
+ However certain programming languages allow developers to express their logic using different methods, 
+ such as visual programming languages that use various geometrical shapes to represent the source code.

--- a/execution/Array.cpp
+++ b/execution/Array.cpp
@@ -59,6 +59,16 @@ std::string GobLang::ArrayNode::toString()
     return text + "]";
 }
 
+void GobLang::ArrayNode::append(MemoryValue const &item)
+{
+    // check if object that we are setting is itself to avoid creating a ref cycle
+    if (item.type == Type::MemoryObj && std::get<MemoryNode *>(item.value) != this)
+    {
+        std::get<MemoryNode *>(item.value)->increaseRefCount();
+    }
+    m_data.push_back(item);
+}
+
 GobLang::ArrayNode::~ArrayNode()
 {
     for (std::vector<MemoryValue>::iterator it = m_data.begin(); it != m_data.end(); it++)

--- a/execution/Array.hpp
+++ b/execution/Array.hpp
@@ -16,6 +16,8 @@ namespace GobLang
 
         size_t getSize() const { return m_data.size(); }
 
+        void append(MemoryValue const& item);
+
         virtual ~ArrayNode();
 
     private:

--- a/execution/Machine.cpp
+++ b/execution/Machine.cpp
@@ -130,7 +130,7 @@ void GobLang::Machine::step()
         m_forcedEnd = true;
         break;
     default:
-        std::cerr << "Invalid op code: " << (int32_t)m_operations[m_programCounter] << std::endl;
+        std::cerr << "Invalid op code: " << (int32_t)m_operations[m_programCounter] << " at " << std::hex << m_programCounter << std::dec << std::endl;
         break;
     }
     m_programCounter++;
@@ -185,7 +185,7 @@ GobLang::MemoryValue *GobLang::Machine::getStackTop()
 
 GobLang::MemoryValue *GobLang::Machine::getStackTopAndPop()
 {
-    if (m_operationStack.empty())
+    if (m_operationStack.back().empty())
     {
         return nullptr;
     }
@@ -223,6 +223,11 @@ GobLang::StringNode *GobLang::Machine::createString(std::string const &str, bool
         m_memoryRoot->pushBack(node);
     }
     return node;
+}
+
+void GobLang::Machine::addObject(MemoryNode *obj)
+{
+    m_memoryRoot->pushBack(obj);
 }
 
 void GobLang::Machine::popStack()

--- a/execution/Machine.hpp
+++ b/execution/Machine.hpp
@@ -84,6 +84,13 @@ namespace GobLang
          */
         StringNode *createString(std::string const &str, bool alwaysNew = false);
 
+        /**
+         * @brief Register object to be handled by the garbage collector. This object will be ref counted and deleted once it is no longer in use 
+         * 
+         * @param obj Object to register
+         */
+        void addObject(MemoryNode * obj);
+
         void popStack();
 
         void pushToStack(MemoryValue const &val);

--- a/execution/Type.cpp
+++ b/execution/Type.cpp
@@ -12,8 +12,6 @@ const char *GobLang::typeToString(Type type)
         return "Float";
     case Type::Int:
         return "Int";
-    case Type::UserData:
-        return "UserData";
     case Type::MemoryObj:
         return "Object";
     case Type::NativeFunction:

--- a/execution/Type.hpp
+++ b/execution/Type.hpp
@@ -10,7 +10,6 @@ namespace GobLang
         Bool,
         Float,
         Int,
-        UserData,
         MemoryObj,
         NativeFunction,
     };

--- a/execution/Value.cpp
+++ b/execution/Value.cpp
@@ -19,8 +19,6 @@ bool GobLang::areEqual(MemoryValue const &a, MemoryValue const &b)
         return std::get<int32_t>(a.value) == std::get<int32_t>(b.value);
     case Type::Char:
         return std::get<char>(a.value) == std::get<char>(b.value);
-    case Type::UserData:
-        return std::get<void *>(a.value) == std::get<void *>(b.value);
     case Type::MemoryObj:
         return std::get<MemoryNode *>(a.value)->equalsTo(std::get<MemoryNode *>(b.value));
     case Type::NativeFunction:
@@ -42,8 +40,6 @@ std::string GobLang::valueToString(MemoryValue const &val)
         return std::to_string(std::get<float>(val.value));
     case Type::Int:
         return std::to_string(std::get<int32_t>(val.value));
-    case Type::UserData:
-        return std::to_string((const size_t)std::get<void *>(val.value));
     case Type::MemoryObj:
         return std::get<MemoryNode *>(val.value)->toString();
     case Type::Char:

--- a/execution/Value.hpp
+++ b/execution/Value.hpp
@@ -11,7 +11,7 @@ namespace GobLang
     class Machine;
     class MemoryNode;
     using FunctionValue = std::function<void(Machine *)>;
-    using Value = std::variant<bool, char, float, int32_t, void *, MemoryNode *, FunctionValue>;
+    using Value = std::variant<bool, char, float, int32_t, MemoryNode *, FunctionValue>;
 
     struct MemoryValue
     {

--- a/standard/File.cpp
+++ b/standard/File.cpp
@@ -1,0 +1,180 @@
+#include "File.hpp"
+
+MachineFunctions::File::FileNode::FileNode(std::string const &path, bool read)
+{
+    if (read)
+    {
+        m_file.open(path, std::fstream::in);
+    }
+    else
+    {
+        m_file.open(path, std::fstream::out);
+    }
+}
+
+void MachineFunctions::File::FileNode::writeToFile(std::string const &str)
+{
+    m_file << str;
+}
+
+void MachineFunctions::File::FileNode::close()
+{
+    m_file.close();
+}
+
+std::string MachineFunctions::File::FileNode::readLine()
+{
+    std::string out;
+    std::getline(m_file, out);
+    return out;
+}
+
+MachineFunctions::File::FileNode::~FileNode()
+{
+    if (m_file.is_open())
+    {
+        m_file.close();
+    }
+}
+
+void MachineFunctions::File::openFile(GobLang::Machine *m)
+{
+    using namespace GobLang;
+    MemoryValue *read = m->getStackTopAndPop();
+    MemoryValue *path = m->getStackTopAndPop();
+    if (path == nullptr)
+    {
+        throw RuntimeException("Missing file name for file open operation");
+    }
+    if (read == nullptr || read->type != Type::Bool)
+    {
+        throw RuntimeException("Missing value for file read mode. Requires true for read and false for write");
+    }
+    if (StringNode *str = dynamic_cast<StringNode *>(std::get<MemoryNode *>(path->value)); str != nullptr)
+    {
+        FileNode *f = new FileNode(str->getString(), std::get<bool>(read->value));
+        m->addObject(f);
+        m->pushToStack(MemoryValue{.type = Type::MemoryObj, .value = f});
+    }
+    else
+    {
+        throw RuntimeException("File open argument is not a string");
+    }
+
+    delete path;
+}
+
+void MachineFunctions::File::closeFile(GobLang::Machine *m)
+{
+    using namespace GobLang;
+    MemoryValue *file = m->getStackTopAndPop();
+    if (file->type != Type::MemoryObj)
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+    if (FileNode *fileNode = dynamic_cast<FileNode *>(std::get<MemoryNode *>(file->value)))
+    {
+        fileNode->close();
+        delete file;
+    }
+    else
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+}
+
+void MachineFunctions::File::isFileOpen(GobLang::Machine *m)
+{
+    using namespace GobLang;
+    MemoryValue *file = m->getStackTopAndPop();
+    if (file->type != Type::MemoryObj)
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+    if (FileNode *fileNode = dynamic_cast<FileNode *>(std::get<MemoryNode *>(file->value)))
+    {
+        m->pushToStack(MemoryValue{.type = Type::Bool, .value = fileNode->isOpen()});
+        delete file;
+    }
+    else
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+}
+
+void MachineFunctions::File::writeToFile(GobLang::Machine *m)
+{
+    using namespace GobLang;
+    MemoryValue *text = m->getStackTopAndPop();
+    MemoryValue *file = m->getStackTopAndPop();
+    if (file == nullptr)
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+    if (text == nullptr)
+    {
+        throw RuntimeException("Expected string argument");
+    }
+    if (file->type != Type::MemoryObj)
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+    if (FileNode *fileNode = dynamic_cast<FileNode *>(std::get<MemoryNode *>(file->value)))
+    {
+        fileNode->writeToFile(valueToString(*text));
+        delete file;
+        delete text;
+    }
+    else
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+}
+
+void MachineFunctions::File::readLineFromFile(GobLang::Machine *m)
+{
+    using namespace GobLang;
+    MemoryValue *file = m->getStackTopAndPop();
+    if (file->type != Type::MemoryObj)
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+    if (FileNode *fileNode = dynamic_cast<FileNode *>(std::get<MemoryNode *>(file->value)))
+    {
+
+        std::string str;
+        if (std::getline(fileNode->getFile(), str))
+        {
+            m->pushToStack(MemoryValue{.type = Type::MemoryObj, .value = m->createString(str)});
+        }
+        else
+        {
+            m->pushToStack(MemoryValue{.type = Type::Null, .value = 0});
+        }
+
+        delete file;
+    }
+    else
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+}
+
+void MachineFunctions::File::isFileEnded(GobLang::Machine *m)
+{
+    using namespace GobLang;
+    MemoryValue *file = m->getStackTopAndPop();
+    if (file->type != Type::MemoryObj)
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+    if (FileNode *fileNode = dynamic_cast<FileNode *>(std::get<MemoryNode *>(file->value)))
+    {
+        m->pushToStack(MemoryValue{.type = Type::Bool, .value = fileNode->isEof()});
+        delete file;
+    }
+    else
+    {
+        throw RuntimeException("Expected file handle object");
+    }
+}

--- a/standard/File.hpp
+++ b/standard/File.hpp
@@ -1,0 +1,52 @@
+#pragma once
+#include <fstream>
+#include "../execution/Machine.hpp"
+
+namespace MachineFunctions::File
+{
+    /**
+     * @brief Very simple and rudimentary file access object. This provides either read or write access to a file.
+     *
+     * Primary purpose is to test out a different object binding system and is subject to change
+     *
+     */
+    class FileNode : public GobLang::MemoryNode
+    {
+    public:
+        explicit FileNode(std::string const &path, bool read);
+
+        void writeToFile(std::string const &str);
+
+        void close();
+
+        bool isOpen() { return m_file.is_open(); }
+
+        bool isEof() { return m_file.eof(); }
+
+        std::string readLine();
+
+        std::fstream &getFile() { return m_file; }
+
+        virtual ~FileNode();
+
+    private:
+        std::fstream m_file;
+    };
+
+    /**
+     * @brief Opens a file and pushes the pointer to the stack
+     *
+     * @param m
+     */
+    void openFile(GobLang::Machine *m);
+
+    void closeFile(GobLang::Machine *m);
+
+    void isFileOpen(GobLang::Machine *m);
+
+    void writeToFile(GobLang::Machine *m);
+
+    void readLineFromFile(GobLang::Machine *m);
+
+    void isFileEnded(GobLang::Machine *m);
+}

--- a/standard/MachineFunctions.cpp
+++ b/standard/MachineFunctions.cpp
@@ -1,6 +1,7 @@
 #include "MachineFunctions.hpp"
 #include "../execution/Array.hpp"
 #include "../execution/Memory.hpp"
+#include "File.hpp"
 #include <random>
 void MachineFunctions::bind(GobLang::Machine *machine)
 {
@@ -9,11 +10,18 @@ void MachineFunctions::bind(GobLang::Machine *machine)
     machine->addFunction(MachineFunctions::print, "print");
     machine->addFunction(MachineFunctions::toString, "str");
     machine->addFunction(MachineFunctions::createArrayOfSize, "array");
+    machine->addFunction(MachineFunctions::append, "append");
     machine->addFunction(MachineFunctions::input, "input");
     machine->addFunction(MachineFunctions::Math::toInt, "int");
     machine->addFunction(MachineFunctions::Math::toFloat, "float");
     machine->addFunction(MachineFunctions::Math::randomIntInRange, "rand_range");
     machine->addFunction(MachineFunctions::Math::randomInt, "rand");
+    machine->addFunction(MachineFunctions::File::openFile, "file_open");
+    machine->addFunction(MachineFunctions::File::closeFile, "file_close");
+    machine->addFunction(MachineFunctions::File::writeToFile, "file_write");
+    machine->addFunction(MachineFunctions::File::isFileOpen, "file_is_open");
+    machine->addFunction(MachineFunctions::File::readLineFromFile, "file_read_line");
+    machine->addFunction(MachineFunctions::File::isFileEnded, "file_is_eof");
 }
 void MachineFunctions::printLine(GobLang::Machine *machine)
 
@@ -47,6 +55,28 @@ void MachineFunctions::createArrayOfSize(GobLang::Machine *machine)
         .type = GobLang::Type::MemoryObj,
         .value = machine->createArrayOfSize(std::get<int32_t>(sizeVal->value))});
     delete sizeVal;
+}
+
+void MachineFunctions::append(GobLang::Machine *machine)
+{
+    using namespace GobLang;
+    GobLang::MemoryValue *val = machine->getStackTopAndPop();
+    GobLang::MemoryValue *array = machine->getStackTopAndPop();
+
+    if (array == nullptr || array->type != Type::MemoryObj)
+    {
+        throw GobLang::RuntimeException("Attempted to append to a non array object");
+    }
+    if (val == nullptr)
+    {
+        throw GobLang::RuntimeException("Missing value for the append operation");
+    }
+    if (GobLang::ArrayNode *arrayNode = dynamic_cast<GobLang::ArrayNode *>(std::get<GobLang::MemoryNode *>(array->value)); arrayNode != nullptr)
+    {
+        arrayNode->append(*val);
+    }
+    delete val;
+    delete array;
 }
 
 void MachineFunctions::getSizeof(GobLang::Machine *machine)

--- a/standard/MachineFunctions.hpp
+++ b/standard/MachineFunctions.hpp
@@ -8,16 +8,18 @@ namespace MachineFunctions
 
     /**
      * @brief Bind all standard functions to the instance of the machine
-     * 
+     *
      * @param machine Instance of the interpreter to bind to
      */
     void bind(GobLang::Machine *machine);
-    
+
     void printLine(GobLang::Machine *machine);
 
     void print(GobLang::Machine *machine);
 
     void createArrayOfSize(GobLang::Machine *machine);
+
+    void append(GobLang::Machine * machine);
 
     void getSizeof(GobLang::Machine *machine);
 
@@ -43,4 +45,5 @@ namespace MachineFunctions
         void toFloat(GobLang::Machine *machine);
 
     }
+
 }


### PR DESCRIPTION
This would change user data system to avoid using `void*`(closing #12 in the process) by removing that option entirely. Now any object that wants to exist in the language runtime, by inheriting from the memory node. This will allow parent code to properly clean up objects when necessary.
Registering objects is done by using `Machine::addObject(MemoryNode * obj)` function

File io works in a way similar to c, although once data structure system would be implemented that should be replaced with a syntax fitting newer approach