### PR TITLE
Change function system to allow using functions as variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(USE_STATIC_BUILD ON CACHE BOOL "Build static executable")
 
 add_compile_definitions(GOB_LANG_VERSION_MAJOR=0)
-add_compile_definitions(GOB_LANG_VERSION_MINOR=6)
+add_compile_definitions(GOB_LANG_VERSION_MINOR=7)
 add_compile_definitions(GOB_LANG_VERSION_PATCH=0)
 
 add_compile_definitions(MAX_PRINT_DEPTH=1000)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ list(APPEND COMMON_SOURCE_FILES execution/Type.hpp
     execution/Structure.cpp
     execution/NativeStructure.hpp
     execution/NativeStructure.cpp
+    execution/FunctionRef.hpp
+    execution/FunctionRef.cpp
 )
 
 

--- a/compiler/Compiler.cpp
+++ b/compiler/Compiler.cpp
@@ -323,14 +323,16 @@ void GobLang::Compiler::Compiler::_generateMultiArg(MultiArgToken const *multiTo
     }
     else if (MethodCallToken *method = dynamic_cast<MethodCallToken *>(*it); method != nullptr)
     {
-        // method call also has to grab the caller which will be the secret first argument   
+        bytes.push_back((uint8_t)Operation::PushConstString);
+        bytes.push_back((uint8_t)method->getMethodNameId());
+        
+        // method call also has to grab the caller which will be the secret first argument
         std::vector<uint8_t> temp = (*stack.rbegin())->getOperationGetBytes();
         bytes.insert(bytes.end(), temp.begin(), temp.end());
         stack.pop_back();
 
-        bytes.push_back((uint8_t)Operation::PushConstString);
-        bytes.push_back((uint8_t)method->getMethodNameId());
-        bytes.push_back((uint8_t)Operation::CallMethod);
+        bytes.push_back((uint8_t)Operation::GetField);
+        bytes.push_back((uint8_t)Operation::Call);
     }
     else if (FunctionCallToken *func = dynamic_cast<FunctionCallToken *>(*it); func != nullptr)
     {

--- a/compiler/CompilerToken.hpp
+++ b/compiler/CompilerToken.hpp
@@ -152,6 +152,19 @@ namespace GobLang::Compiler
         size_t m_varId;
     };
 
+    class LocalFunctionAccessToken : public Token
+    {
+    public:
+        explicit LocalFunctionAccessToken(size_t row, size_t column, size_t id) : Token(row, column), m_funcId(id) {}
+
+        size_t getId() const { return m_funcId; }
+
+        std::string toString() override { return "FUNC_" + std::to_string(m_funcId); }
+
+    private:
+        size_t m_funcId;
+    };
+
     class LocalVarShrinkToken : public Token
     {
     public:

--- a/compiler/ReversePolishGenerator.cpp
+++ b/compiler/ReversePolishGenerator.cpp
@@ -183,6 +183,13 @@ int32_t GobLang::Compiler::ReversePolishGenerator::_getLocalVariableAccessId(siz
     return found ? (int32_t)curr : -1;
 }
 
+size_t GobLang::Compiler::ReversePolishGenerator::_getFunctionAccessId(size_t nameId)
+{
+    auto it = std::find_if(m_funcs.begin(), m_funcs.end(), [nameId](FunctionTokenSequence const *func)
+                           { return func->getInfo()->nameId == nameId; });
+    return it == m_funcs.end() ? -1 : (it - m_funcs.begin());
+}
+
 void GobLang::Compiler::ReversePolishGenerator::_appendVariableBlock()
 {
     m_blockVariables.push_back({});
@@ -847,6 +854,12 @@ void GobLang::Compiler::ReversePolishGenerator::_compileIdToken(IdToken const *i
         if (SeparatorToken *sepTok = dynamic_cast<SeparatorToken *>(*(m_it + 1)); sepTok != nullptr && sepTok->getSeparator() == Separator::BracketOpen)
         {
             return;
+        }
+        else if (size_t funcId = _getFunctionAccessId(id->getId()); funcId != -1)
+        {
+            LocalFunctionAccessToken *local = new LocalFunctionAccessToken(id->getRow(), id->getColumn(), funcId);
+            addToken(local);
+            m_compilerTokens.push_back(local);
         }
     }
     else if (int32_t varId = _getLocalVariableAccessId(id->getId()); varId != -1)

--- a/compiler/ReversePolishGenerator.hpp
+++ b/compiler/ReversePolishGenerator.hpp
@@ -78,6 +78,7 @@ namespace GobLang::Compiler
     private:
         bool _doesVariableExist(size_t stringId);
         int32_t _getLocalVariableAccessId(size_t id);
+        size_t _getFunctionAccessId(size_t nameId);
         void _appendVariableBlock();
         void _popVariableBlock();
         void _appendVariable(size_t stringId);

--- a/examples/filter.gob
+++ b/examples/filter.gob
@@ -1,0 +1,19 @@
+func filter(array, f){
+    let result = [];
+    let i = 0;
+    while(i < sizeof(array)){
+        if (f(array[i]) == true){
+            append(result, array[i]);
+        }
+        i += 1;
+    }
+    return result;
+}
+
+func cond(a){
+    return a % 2 == 0;
+}
+
+let test = [1,2,3,4,5,6,7];
+
+print_line(filter(test,cond));

--- a/execution/FunctionRef.cpp
+++ b/execution/FunctionRef.cpp
@@ -4,3 +4,7 @@ GobLang::FunctionRef::FunctionRef(FunctionValue const * func, MemoryNode *owner)
 {
 
 }
+
+GobLang::FunctionRef::FunctionRef(size_t localFuncId) : m_localFuncId(localFuncId)
+{
+}

--- a/execution/FunctionRef.cpp
+++ b/execution/FunctionRef.cpp
@@ -1,0 +1,6 @@
+#include "FunctionRef.hpp"
+
+GobLang::FunctionRef::FunctionRef(FunctionValue const * func, MemoryNode *owner) : m_func(func), m_owner(owner)
+{
+
+}

--- a/execution/FunctionRef.hpp
+++ b/execution/FunctionRef.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include "Memory.hpp"
+#include "Value.hpp"
+namespace GobLang
+{
+    class FunctionRef : public MemoryNode
+    {
+    public:
+        explicit FunctionRef(FunctionValue const *func, MemoryNode *owner = nullptr);
+        bool hasOwner() const { return m_owner != nullptr; }
+        MemoryNode *getOwner() { return m_owner; }
+        FunctionValue const *getFunction() const { return m_func; }
+
+    private:
+        /// @brief The object that owns this function. If null then this function is static
+        MemoryNode *m_owner;
+        /// @brief The actual function object. Either an int to reference id of a function or NativeFunction object
+        FunctionValue const *m_func;
+    };
+}

--- a/execution/FunctionRef.hpp
+++ b/execution/FunctionRef.hpp
@@ -7,7 +7,10 @@ namespace GobLang
     {
     public:
         explicit FunctionRef(FunctionValue const *func, MemoryNode *owner = nullptr);
+        explicit FunctionRef(size_t localFuncId);
         bool hasOwner() const { return m_owner != nullptr; }
+        bool isLocal() const { return m_localFuncId != -1; }
+        size_t getLocalFuncId() const { return m_localFuncId; }
         MemoryNode *getOwner() { return m_owner; }
         FunctionValue const *getFunction() const { return m_func; }
 
@@ -16,5 +19,7 @@ namespace GobLang
         MemoryNode *m_owner;
         /// @brief The actual function object. Either an int to reference id of a function or NativeFunction object
         FunctionValue const *m_func;
+
+        size_t m_localFuncId = -1;
     };
 }

--- a/execution/Machine.cpp
+++ b/execution/Machine.cpp
@@ -272,7 +272,11 @@ GobLang::StringNode *GobLang::Machine::createString(std::string const &str, bool
 
 void GobLang::Machine::addObject(MemoryNode *obj)
 {
-    m_memoryRoot.pushBack(obj);
+    if (!obj->isRegistered())
+    {
+        obj->registerGC();
+        m_memoryRoot.pushBack(obj);
+    }
 }
 
 void GobLang::Machine::popStack()
@@ -974,7 +978,12 @@ inline void GobLang::Machine::_getField()
     {
         if (StringNode *strNode = dynamic_cast<StringNode *>(std::get<MemoryNode *>(field.value)); strNode != nullptr)
         {
-            pushToStack(arrNode->getField(strNode->getString()));
+            MemoryValue v = arrNode->getField(strNode->getString());
+            if(std::holds_alternative<MemoryNode*>(v.value))
+            {
+                addObject(std::get<MemoryNode*>(v.value));
+            }
+            pushToStack(v);
         }
         else
         {

--- a/execution/Machine.hpp
+++ b/execution/Machine.hpp
@@ -119,6 +119,10 @@ namespace GobLang
 
         void removeFunctionFrame();
 
+        /// @brief Call local function that is stored under id funcId
+        /// @param funcId Id of the function
+        void callLocalFunction(size_t funcId);
+
         /**
          * @brief Create a custom variable that will be accessible in code. Useful for binding with c code
          *
@@ -203,7 +207,7 @@ namespace GobLang
 
         inline void _call();
 
-        inline void _callLocal();
+        inline void _getLocalFunc();
 
         inline void _return();
 

--- a/execution/Memory.hpp
+++ b/execution/Memory.hpp
@@ -52,6 +52,12 @@ namespace GobLang
 
         int32_t getRefCount() const { return m_refCount; }
 
+        /// @brief Whether this object has been added to garbage collector
+        /// @return true if  this object is being tracked by the garbage collector
+        bool isRegistered() const { return m_registered; }
+
+        void registerGC() { m_registered = true; }
+
         /**
          * @brief Size of the memory chain
          *
@@ -70,7 +76,7 @@ namespace GobLang
 
         /**
          * @brief Convert given object into a string representation
-         * 
+         *
          * @param pretty If true then this object should be printed with type decorations. Only is relevant for string types
          * @return std::string String representation
          */
@@ -91,6 +97,8 @@ namespace GobLang
         bool m_dead = false;
 
         int32_t m_refCount = 0;
+
+        bool m_registered = false;
     };
 
     class StringNode : public MemoryNode

--- a/execution/NativeStructure.cpp
+++ b/execution/NativeStructure.cpp
@@ -1,4 +1,6 @@
 #include "NativeStructure.hpp"
+#include "Machine.hpp"
+#include "FunctionRef.hpp"
 
 bool GobLang::Struct::NativeStructureObjectNode::hasNativeMethod(std::string const &name)
 {
@@ -7,6 +9,15 @@ bool GobLang::Struct::NativeStructureObjectNode::hasNativeMethod(std::string con
         return false;
     }
     return m_nativeStruct->methods.count(name);
+}
+
+GobLang::MemoryValue GobLang::Struct::NativeStructureObjectNode::getField(std::string const &field)
+{
+    if (FunctionValue const *f = getNativeMethod(field); f != nullptr)
+    {
+        return MemoryValue{.type = Type::MemoryObj, .value = new FunctionRef(f, this)};
+    }
+    return StructureObjectNode::getField(field);
 }
 
 GobLang::FunctionValue const *GobLang::Struct::NativeStructureObjectNode::getNativeMethod(std::string const &name) const

--- a/execution/NativeStructure.hpp
+++ b/execution/NativeStructure.hpp
@@ -21,6 +21,7 @@ namespace GobLang::Struct
             Structure const *baseInfo = nullptr) : StructureObjectNode(baseInfo), m_nativeStruct(info) {}
 
         bool hasNativeMethod(std::string const &name) override;
+        MemoryValue getField(std::string const &field) override;
 
         FunctionValue const *getNativeMethod(std::string const &name) const override;
 

--- a/execution/Operations.hpp
+++ b/execution/Operations.hpp
@@ -16,7 +16,7 @@ namespace GobLang
         /**
          * @brief Call a function defined by the user
          */
-        CallLocal,
+        GetLocalFunction,
         Set,
         Get,
         GetLocal,
@@ -122,7 +122,7 @@ namespace GobLang
         OperationData{.op = Operation::Div, .text = "div", .argType = OperatorArgType::None},
         OperationData{.op = Operation::Modulo, .text = "mod", .argType = OperatorArgType::None},
         OperationData{.op = Operation::Call, .text = "call", .argType = OperatorArgType::None},
-        OperationData{.op = Operation::CallLocal, .text = "call_local", .argType = OperatorArgType::Byte},
+        OperationData{.op = Operation::GetLocalFunction, .text = "get_local_func", .argType = OperatorArgType::Byte},
         OperationData{.op = Operation::CreateArray, .text = "create_array", .argType = OperatorArgType::Byte},
         OperationData{.op = Operation::Set, .text = "set_global", .argType = OperatorArgType::None},
         OperationData{.op = Operation::Get, .text = "get_global", .argType = OperatorArgType::None},

--- a/execution/Structure.hpp
+++ b/execution/Structure.hpp
@@ -41,7 +41,7 @@ namespace GobLang::Struct
     public:
         explicit StructureObjectNode(Structure const *base);
         void setField(std::string const &field, MemoryValue const &value);
-        MemoryValue getField(std::string const &field);
+        virtual MemoryValue getField(std::string const &field);
 
         virtual bool hasNativeMethod(std::string const &name) { return false; }
 


### PR DESCRIPTION
This changes how functions are processed to bring same system of functions are was available with native functions
This way functions can be used in callbacks or as predicates
```
func f1(p){
return p(1);
}

func f2(num){
return num + num;
}

f1(f2);
```

This also allows storing function owner in the reference for method calls(only works with native ones right now)