### PR TITLE
Add break and continue control operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5.0)
-project(goblang VERSION 0.3.0 LANGUAGES C CXX)
+cmake_minimum_required(VERSION 3.20.0)
+project(goblang VERSION 0.7.0 LANGUAGES C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20.0)
 project(goblang VERSION 0.7.0 LANGUAGES C CXX)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED true)
 
 set(USE_STATIC_BUILD ON CACHE BOOL "Build static executable")
 

--- a/codegen/Builder.cpp
+++ b/codegen/Builder.cpp
@@ -183,6 +183,15 @@ std::unique_ptr<GobLang::Codegen::CodeGenValue> GobLang::Codegen::Builder::creat
         (uint8_t)(funcIt - m_functions.begin())});
 }
 
+GobLang::Codegen::BlockContext *GobLang::Codegen::Builder::getCurrentBlock()
+{
+    if (m_blocks.empty())
+    {
+        return nullptr;
+    }
+    return m_blocks.back().get();
+}
+
 bool GobLang::Codegen::Builder::isCurrentlyInFunction()
 {
     for (std::vector<std::unique_ptr<GobLang::Codegen::BlockContext>>::const_iterator it = m_blocks.begin(); it != m_blocks.end(); it++)

--- a/codegen/Builder.hpp
+++ b/codegen/Builder.hpp
@@ -48,7 +48,7 @@ namespace GobLang::Codegen
 
         std::unique_ptr<CodeGenValue> createLocalFunctionAccess(size_t nameId);
 
-        BlockContext *getCurrentBlock() { return m_blocks.back().get(); }
+        BlockContext *getCurrentBlock();
 
         bool isCurrentlyInFunction();
 

--- a/codegen/CodeGenValue.cpp
+++ b/codegen/CodeGenValue.cpp
@@ -118,7 +118,7 @@ std::vector<uint8_t> GobLang::Codegen::BranchCodeGenValue::getGetOperationBytes(
     if (m_jumpAfter != -1)
     {
         bytes.push_back(m_backwards ? (uint8_t)Operation::JumpBack : (uint8_t)Operation::Jump);
-        std::vector<uint8_t> num = parseToBytes(m_jumpAfter);
+        std::vector<uint8_t> num = parseToBytes((uint32_t)m_jumpAfter);
         bytes.insert(bytes.end(), num.begin(), num.end());
     }
     return bytes;
@@ -126,21 +126,21 @@ std::vector<uint8_t> GobLang::Codegen::BranchCodeGenValue::getGetOperationBytes(
 
 void GobLang::Codegen::BranchCodeGenValue::setConditionJumpOffset(size_t offset)
 {
-    std::vector<uint8_t> num = parseToBytes(offset);
+    std::vector<uint8_t> num = parseToBytes((uint32_t)offset);
     std::copy(num.begin(), num.end(), m_condBytes.end() - sizeof(ProgramAddressType));
 }
 
-size_t GobLang::Codegen::BranchCodeGenValue::getBodySize()
+size_t GobLang::Codegen::BranchCodeGenValue::getBodySize() const
 {
     return m_bodyBytes.size() + ((m_jumpAfter != -1) ? (sizeof(ProgramAddressType) + 1) : 0);
 }
 
-size_t GobLang::Codegen::BranchCodeGenValue::getFullSize()
+size_t GobLang::Codegen::BranchCodeGenValue::getFullSize() const
 {
     return m_condBytes.size() + getBodySize();
 }
 
-size_t GobLang::Codegen::BranchCodeGenValue::getConditionSize()
+size_t GobLang::Codegen::BranchCodeGenValue::getConditionSize() const
 {
     return m_condBytes.size();
 }

--- a/codegen/CodeGenValue.cpp
+++ b/codegen/CodeGenValue.cpp
@@ -73,11 +73,26 @@ void GobLang::Codegen::BlockContext::insert(std::vector<uint8_t> const &bytes)
 
 void GobLang::Codegen::BlockContext::appendMemoryClear()
 {
-    if (m_variables.size() > 0)
+    if (!m_variables.empty())
     {
         m_bytes.push_back((uint8_t)Operation::ShrinkLocal);
         m_bytes.push_back((uint8_t)m_variables.size());
     }
+}
+
+void GobLang::Codegen::BlockContext::addJump(bool isBreak)
+{
+    m_jumps[m_bytes.size() + m_baseJumpOffset] = isBreak;
+}
+
+void GobLang::Codegen::BlockContext::addJumpAt(size_t offset, bool isBreak)
+{
+    m_jumps[m_bytes.size() + offset + m_baseJumpOffset] = isBreak;
+}
+
+void GobLang::Codegen::BlockContext::createBaseJumpOffset(size_t offset)
+{
+    m_baseJumpOffset = offset;
 }
 
 GobLang::Codegen::BranchCodeGenValue::BranchCodeGenValue(std::vector<uint8_t> cond, std::vector<uint8_t> body)

--- a/codegen/CodeGenValue.hpp
+++ b/codegen/CodeGenValue.hpp
@@ -44,18 +44,26 @@ namespace GobLang::Codegen
 
         void insert(std::vector<uint8_t> const &bytes);
 
-        std::vector<uint8_t> const &getBytes() { return m_bytes; }
+        std::vector<uint8_t> const &getBytes() const { return m_bytes; }
 
         /// @brief Append instructions for clearing variable stack
         void appendMemoryClear();
 
         bool isFunction() const { return m_funcId != -1; }
 
+        void addJump(bool isBreak);
+
+        void addJumpAt(size_t offset, bool isBreak);
+
+        void createBaseJumpOffset(size_t offset);
+
+        std::map<size_t, bool> const &getJumps() const { return m_jumps; }
+
     private:
-        std::map<size_t, size_t> m_jumps;
+        std::map<size_t, bool> m_jumps;
         std::vector<size_t> m_variables;
         std::vector<uint8_t> m_bytes;
-
+        size_t m_baseJumpOffset = 0;
         size_t m_funcId = -1;
     };
 
@@ -77,6 +85,8 @@ namespace GobLang::Codegen
         explicit BlockCodeGenValue(std::unique_ptr<BlockContext> block);
 
         std::vector<uint8_t> getGetOperationBytes() override { return m_block->getBytes(); }
+
+        BlockContext const *getBlock() const { return m_block.get(); }
 
     private:
         std::unique_ptr<BlockContext> m_block;

--- a/codegen/CodeGenValue.hpp
+++ b/codegen/CodeGenValue.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <memory>
 #include <algorithm>
+#include <bit>
 #include "../execution/Function.hpp"
 
 namespace GobLang::Codegen
@@ -11,13 +12,13 @@ namespace GobLang::Codegen
     template <typename T>
     std::vector<uint8_t> parseToBytes(T val)
     {
-        uint32_t *v = reinterpret_cast<uint32_t *>(&val);
+        uint32_t const v =  std::bit_cast<uint32_t>(val);
         std::vector<uint8_t> res;
         for (int32_t i = sizeof(T) - 1; i >= 0; i--)
         {
             uint64_t offset = (sizeof(uint8_t) * i) * 8;
             const size_t mask = 0xff;
-            uint64_t num = (*v) & (mask << offset);
+            uint64_t num = v & (mask << offset);
             uint64_t numFixed = num >> offset;
             res.push_back((uint8_t)numFixed);
         }
@@ -80,8 +81,6 @@ namespace GobLang::Codegen
         virtual std::vector<uint8_t> getGetOperationBytes() = 0;
 
         virtual std::vector<uint8_t> getSetOperationBytes() { return {}; }
-
-    private:
     };
 
     class BlockCodeGenValue : public CodeGenValue
@@ -152,13 +151,13 @@ namespace GobLang::Codegen
 
         /// @brief Get size of the body block in bytes, accounting for the optional end jump
         /// @return
-        size_t getBodySize();
+        size_t getBodySize() const;
 
         /// @brief Get the full size of the block in bytes
         /// @return
-        size_t getFullSize();
+        size_t getFullSize() const;
 
-        size_t getConditionSize();
+        size_t getConditionSize() const;
 
         bool hasEndJump() const { return m_jumpAfter != -1; }
 

--- a/codegen/CodeGenValue.hpp
+++ b/codegen/CodeGenValue.hpp
@@ -57,6 +57,10 @@ namespace GobLang::Codegen
 
         void createBaseJumpOffset(size_t offset);
 
+        void markAsLoopBlock() { m_loopBlock = true; }
+
+        bool isLoopBlock() const { return m_loopBlock; }
+
         std::map<size_t, bool> const &getJumps() const { return m_jumps; }
 
     private:
@@ -65,6 +69,7 @@ namespace GobLang::Codegen
         std::vector<uint8_t> m_bytes;
         size_t m_baseJumpOffset = 0;
         size_t m_funcId = -1;
+        bool m_loopBlock;
     };
 
     class CodeGenValue

--- a/codegen/CodeGenValue.hpp
+++ b/codegen/CodeGenValue.hpp
@@ -93,6 +93,8 @@ namespace GobLang::Codegen
 
         BlockContext const *getBlock() const { return m_block.get(); }
 
+        size_t getBlockSize() const { return m_block->getBytes().size(); }
+
     private:
         std::unique_ptr<BlockContext> m_block;
     };

--- a/codegen/CodeGenerator.cpp
+++ b/codegen/CodeGenerator.cpp
@@ -200,7 +200,7 @@ std::unique_ptr<BranchNode> GobLang::Codegen::CodeGenerator::parseBranch()
     }
     consumeSeparator(Separator::BracketClose, "Expected ')'");
     consumeSeparator(Separator::BlockOpen, "Expected '{'");
-    std::unique_ptr<CodeNode> body = parseBody();
+    std::unique_ptr<SequenceNode> body = parseBody();
     consumeSeparator(Separator::BlockClose, "Expected '}'");
 
     return std::make_unique<BranchNode>(std::move(cond), std::move(body));
@@ -218,7 +218,7 @@ std::unique_ptr<WhileLoopNode> GobLang::Codegen::CodeGenerator::parseLoop()
     }
     consumeSeparator(Separator::BracketClose, "Expected ')'");
     consumeSeparator(Separator::BlockOpen, "Expected '{'");
-    std::unique_ptr<CodeNode> body = parseBody();
+    std::unique_ptr<SequenceNode> body = parseBody();
     consumeSeparator(Separator::BlockClose, "Expected '}'");
 
     return std::make_unique<WhileLoopNode>(std::move(cond), std::move(body));

--- a/codegen/CodeGenerator.cpp
+++ b/codegen/CodeGenerator.cpp
@@ -236,7 +236,7 @@ std::unique_ptr<BranchChainNode> GobLang::Codegen::CodeGenerator::parseBranchCha
     {
         elifs.push_back(std::move(parseBranch()));
     }
-    std::unique_ptr<CodeNode> elseBlock = nullptr;
+    std::unique_ptr<SequenceNode> elseBlock = nullptr;
 
     if (isKeyword(Keyword::Else))
     {

--- a/codegen/CodeGenerator.cpp
+++ b/codegen/CodeGenerator.cpp
@@ -112,14 +112,15 @@ std::unique_ptr<SequenceNode> GobLang::Codegen::CodeGenerator::parseBody()
         {
             seq.push_back(std::move(parseStandaloneExpression()));
         }
+        else if (isSeparator(Separator::BlockClose) || isAtTheEnd())
+        {
+            break;
+        }
         else
         {
             error("Unknown character sequence");
         }
-        if (isSeparator(Separator::BlockClose) || isAtTheEnd())
-        {
-            break;
-        }
+        
     }
     return std::make_unique<SequenceNode>(std::move(seq));
 }

--- a/codegen/CodeNode.hpp
+++ b/codegen/CodeNode.hpp
@@ -16,7 +16,6 @@ namespace GobLang::Codegen
 
         virtual std::string toString() = 0;
 
-    private:
     };
 
     class IdNode : public CodeNode
@@ -239,7 +238,10 @@ namespace GobLang::Codegen
         std::unique_ptr<BranchCodeGenValue> generateBranchCode(Builder &builder, size_t prevBranchOffset = 0);
         std::string toString() override;
 
-    protected:
+        std::unique_ptr<CodeNode> &getCond() { return m_cond; }
+        std::unique_ptr<SequenceNode> &getBody() { return m_body; }
+
+    private:
         std::unique_ptr<CodeNode> m_cond;
         std::unique_ptr<SequenceNode> m_body;
     };

--- a/codegen/CodeNode.hpp
+++ b/codegen/CodeNode.hpp
@@ -102,7 +102,7 @@ namespace GobLang::Codegen
     {
     public:
         explicit BreakNode() = default;
-        std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override { return nullptr; }
+        std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override;
         std::string toString() override;
     };
 
@@ -110,7 +110,7 @@ namespace GobLang::Codegen
     {
     public:
         explicit ContinueNode() = default;
-        std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override { return nullptr; }
+        std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override;
         std::string toString() override;
     };
 
@@ -137,7 +137,8 @@ namespace GobLang::Codegen
     {
     public:
         explicit SequenceNode(std::vector<std::unique_ptr<CodeNode>> seq);
-        std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override;
+        std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override { return generateBlockContext(builder); }
+        std::unique_ptr<BlockCodeGenValue> generateBlockContext(Builder &builder);
         std::string toString() override;
 
     private:
@@ -224,7 +225,7 @@ namespace GobLang::Codegen
     class BranchNode : public CodeNode
     {
     public:
-        explicit BranchNode(std::unique_ptr<CodeNode> cond, std::unique_ptr<CodeNode> body);
+        explicit BranchNode(std::unique_ptr<CodeNode> cond, std::unique_ptr<SequenceNode> body);
         std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override { return generateBranchCode(builder); }
 
         std::unique_ptr<BranchCodeGenValue> generateBranchCode(Builder &builder);
@@ -232,13 +233,13 @@ namespace GobLang::Codegen
 
     protected:
         std::unique_ptr<CodeNode> m_cond;
-        std::unique_ptr<CodeNode> m_body;
+        std::unique_ptr<SequenceNode> m_body;
     };
 
     class WhileLoopNode : public BranchNode
     {
     public:
-        explicit WhileLoopNode(std::unique_ptr<CodeNode> cond, std::unique_ptr<CodeNode> body);
+        explicit WhileLoopNode(std::unique_ptr<CodeNode> cond, std::unique_ptr<SequenceNode> body);
         std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override;
         std::string toString() override;
     };

--- a/codegen/CodeNode.hpp
+++ b/codegen/CodeNode.hpp
@@ -138,7 +138,11 @@ namespace GobLang::Codegen
     public:
         explicit SequenceNode(std::vector<std::unique_ptr<CodeNode>> seq);
         std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override { return generateBlockContext(builder); }
-        std::unique_ptr<BlockCodeGenValue> generateBlockContext(Builder &builder);
+        /// @brief Generate block codegen data for the given sequence
+        /// @param builder
+        /// @param jumpStartOffset
+        /// @return
+        std::unique_ptr<BlockCodeGenValue> generateBlockContext(Builder &builder, size_t jumpStartOffset = 0, bool isLoop = false);
         std::string toString() override;
 
     private:
@@ -228,7 +232,11 @@ namespace GobLang::Codegen
         explicit BranchNode(std::unique_ptr<CodeNode> cond, std::unique_ptr<SequenceNode> body);
         std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override { return generateBranchCode(builder); }
 
-        std::unique_ptr<BranchCodeGenValue> generateBranchCode(Builder &builder);
+        /// @brief Create a branch codegen value
+        /// @param builder Bytecode builder
+        /// @param prevBranchOffset Offset based on the size of the previous if/elif branches, used for proper break/continue handling
+        /// @return
+        std::unique_ptr<BranchCodeGenValue> generateBranchCode(Builder &builder, size_t prevBranchOffset = 0);
         std::string toString() override;
 
     protected:
@@ -247,14 +255,17 @@ namespace GobLang::Codegen
     class BranchChainNode : public CodeNode
     {
     public:
-        explicit BranchChainNode(std::unique_ptr<BranchNode> primary, std::vector<std::unique_ptr<BranchNode>> secondary, std::unique_ptr<CodeNode> elseBlock = nullptr);
+        explicit BranchChainNode(
+            std::unique_ptr<BranchNode> primary,
+            std::vector<std::unique_ptr<BranchNode>> secondary,
+            std::unique_ptr<SequenceNode> elseBlock = nullptr);
         std::string toString() override;
         std::unique_ptr<CodeGenValue> generateCode(Builder &builder) override;
 
     private:
         std::unique_ptr<BranchNode> m_primary;
         std::vector<std::unique_ptr<BranchNode>> m_secondary;
-        std::unique_ptr<CodeNode> m_else;
+        std::unique_ptr<SequenceNode> m_else;
     };
 
     class VariableCreationNode : public CodeNode

--- a/codegen/Lexems.hpp
+++ b/codegen/Lexems.hpp
@@ -110,7 +110,7 @@ namespace GobLang::Codegen
      * @brief Info about all keywords used in the parser
      *
      */
-    static const std::map<std::string, Keyword> Keywords = {
+    static const std::map<std::string, Keyword,  std::less<>> Keywords = {
         //{"int", Keyword::Int},
         //{"float", Keyword::Float},
         {"func", Keyword::Function},
@@ -126,7 +126,7 @@ namespace GobLang::Codegen
         {"let", Keyword::Let},
         {"type", Keyword::Struct}};
 
-    static const std::map<std::string, bool> Booleans = {
+    static const std::map<std::string, bool,  std::less<>> Booleans = {
         {"true", true},
         {"false", false},
         {"True", true},

--- a/execution/Value.hpp
+++ b/execution/Value.hpp
@@ -12,7 +12,7 @@ namespace GobLang
      * @brief Type used to store jump addresses in the code
      *
      */
-    using ProgramAddressType = size_t;
+    using ProgramAddressType = uint32_t;
     static size_t MAX_PRINT_RECURSION_DEPTH = MAX_PRINT_DEPTH;
     class Machine;
     class MemoryNode;

--- a/indev.cpp
+++ b/indev.cpp
@@ -10,7 +10,7 @@
 #include "codegen/Disassembly.hpp"
 
 //#define INDEV_DEBUG_TREE_ONLY
-#define INDEV_DEBUG_RUN_FULL_CODE
+//#define INDEV_DEBUG_RUN_FULL_CODE
 #define INDEV_DEBUG_SHOW_TREE
 
 using namespace GobLang;

--- a/indev.cpp
+++ b/indev.cpp
@@ -10,7 +10,7 @@
 #include "codegen/Disassembly.hpp"
 
 //#define INDEV_DEBUG_TREE_ONLY
-//#define INDEV_DEBUG_RUN_FULL_CODE
+#define INDEV_DEBUG_RUN_FULL_CODE
 #define INDEV_DEBUG_SHOW_TREE
 
 using namespace GobLang;


### PR DESCRIPTION
Due to changes in parser the break and continue system can not be processed the same way. This makes the if-chain bytecode generation function even more complex , however it hopefully should not require any additional changes thanks to a more modular approach in the bytecode generation process