### PR TITLE
change value system to only use std::variant

### DIFF
--- a/examples/read_all_lines.gob
+++ b/examples/read_all_lines.gob
@@ -9,7 +9,7 @@ func read_all_lines(file)
 }
 
 
-file = File("./text.txt", true);
+file = new File("./text.txt", true);
 if(!file.is_open()){
     print_line("Unable to open file");
 }

--- a/examples/read_and_write_to_file.gob
+++ b/examples/read_and_write_to_file.gob
@@ -1,4 +1,4 @@
-let file = File("./text.txt", false);
+let file = new File("./text.txt", false);
 if(!file.is_open()){
     print_line("Unable to open file");
 }
@@ -7,7 +7,7 @@ else{
     file.write("new way!");
     file.close();
 }
-file = File("./text.txt", true);
+file = new File("./text.txt", true);
 if(!file.is_open()){
     print_line("Unable to open file");
 }

--- a/execution/Array.cpp
+++ b/execution/Array.cpp
@@ -3,9 +3,9 @@
 #include "Exception.hpp"
 GobLang::ArrayNode::ArrayNode(size_t size)
 {
-    m_data = std::vector<MemoryValue>(size);
+    m_data = std::vector<Value>(size);
 }
-void GobLang::ArrayNode::setItem(size_t i, MemoryValue const &item)
+void GobLang::ArrayNode::setItem(size_t i, Value const &item)
 {
     if (i >= m_data.size())
     {
@@ -16,18 +16,18 @@ void GobLang::ArrayNode::setItem(size_t i, MemoryValue const &item)
             std::to_string(m_data.size()));
     }
     // check if object that we are setting is itself to avoid creating a ref cycle
-    if (item.type == Type::MemoryObj && std::get<MemoryNode *>(item.value) != this)
+    if ((Type)item.index() == Type::MemoryObj && std::get<MemoryNode *>(item) != this)
     {
-        std::get<MemoryNode *>(item.value)->increaseRefCount();
+        std::get<MemoryNode *>(item)->increaseRefCount();
     }
-    if (m_data[i].type == Type::MemoryObj && std::get<MemoryNode *>(m_data[i].value) != this)
+    if ((Type)m_data[i].index() == Type::MemoryObj && std::get<MemoryNode *>(m_data[i]) != this)
     {
-        std::get<MemoryNode *>(m_data[i].value)->decreaseRefCount();
+        std::get<MemoryNode *>(m_data[i])->decreaseRefCount();
     }
     m_data[i] = item;
 }
 
-GobLang::MemoryValue *GobLang::ArrayNode::getItem(size_t i)
+GobLang::Value *GobLang::ArrayNode::getItem(size_t i)
 {
 
     if (i < m_data.size())
@@ -59,23 +59,23 @@ std::string GobLang::ArrayNode::toString(bool pretty, size_t depth)
     return text + "]";
 }
 
-void GobLang::ArrayNode::append(MemoryValue const &item)
+void GobLang::ArrayNode::append(Value const &item)
 {
     // check if object that we are setting is itself to avoid creating a ref cycle
-    if (item.type == Type::MemoryObj && std::get<MemoryNode *>(item.value) != this)
+    if ((Type)item.index() == Type::MemoryObj && std::get<MemoryNode *>(item) != this)
     {
-        std::get<MemoryNode *>(item.value)->increaseRefCount();
+        std::get<MemoryNode *>(item)->increaseRefCount();
     }
     m_data.push_back(item);
 }
 
 GobLang::ArrayNode::~ArrayNode()
 {
-    for (std::vector<MemoryValue>::iterator it = m_data.begin(); it != m_data.end(); it++)
+    for (std::vector<Value>::iterator it = m_data.begin(); it != m_data.end(); it++)
     {
-        if (it->type == Type::MemoryObj)
+        if ((Type)it->index() == Type::MemoryObj)
         {
-            std::get<MemoryNode *>(it->value)->decreaseRefCount();
+            std::get<MemoryNode *>((*it))->decreaseRefCount();
         }
     }
 }

--- a/execution/Array.hpp
+++ b/execution/Array.hpp
@@ -3,24 +3,23 @@
 
 namespace GobLang
 {
-    struct MemoryValue;
     class ArrayNode : public MemoryNode
     {
     public:
         explicit ArrayNode(size_t size);
 
-        void setItem(size_t i, MemoryValue const &item);
-        MemoryValue *getItem(size_t i);
+        void setItem(size_t i, Value const &item);
+        Value *getItem(size_t i);
 
         std::string toString(bool pretty, size_t depth) override;
 
         size_t getSize() const { return m_data.size(); }
 
-        void append(MemoryValue const& item);
+        void append(Value const& item);
 
         virtual ~ArrayNode();
 
     private:
-        std::vector<MemoryValue> m_data;
+        std::vector<Value> m_data;
     };
 } // namespace SimpleLang

--- a/execution/Memory.cpp
+++ b/execution/Memory.cpp
@@ -9,26 +9,26 @@ GobLang::MemoryNode::MemoryNode(Struct::Structure const *base) : m_struct(base)
     for (Field const &field : base->fields)
     {
         m_fieldNames[field.name] = m_fields.size();
-        m_fields.push_back(MemoryValue{.type = Type::Null, .value = 0});
+        m_fields.push_back(Value(nullptr));
         // switch (field.type)
         // {
         // case StructureFieldType::Char:
-        //     m_fields.push_back(MemoryValue{.type = Type::Char, .value = '\0'});
+        //     m_fields.push_back(Value{.type = Type::Char, .value = '\0'});
         //     break;
         // case StructureFieldType::Bool:
-        //     m_fields.push_back(MemoryValue{.type = Type::Char, .value = false});
+        //     m_fields.push_back(Value{.type = Type::Char, .value = false});
         //     break;
         // case StructureFieldType::Float:
-        //     m_fields.push_back(MemoryValue{.type = Type::Float, .value = 0.f});
+        //     m_fields.push_back(Value{.type = Type::Float, .value = 0.f});
         //     break;
         // case StructureFieldType::Int:
-        //     m_fields.push_back(MemoryValue{.type = Type::Int, .value = 0});
+        //     m_fields.push_back(Value{.type = Type::Int, .value = 0});
         //     break;
         // case StructureFieldType::UnsignedInt:
-        //     m_fields.push_back(MemoryValue{.type = Type::Int, .value = 0u});
+        //     m_fields.push_back(Value{.type = Type::Int, .value = 0u});
         //     break;
         // default:
-        //     m_fields.push_back(MemoryValue{.type = Type::Null, .value = 0});
+        //     m_fields.push_back(Value{.type = Type::Null, .value = 0});
         //     break;
         // }
     }
@@ -76,7 +76,7 @@ void GobLang::MemoryNode::decreaseRefCount()
     m_refCount--;
 }
 
-void GobLang::MemoryNode::setField(std::string const &field, MemoryValue const &value)
+void GobLang::MemoryNode::setField(std::string const &field, Value const &value)
 {
     if (m_fieldNames.count(field) == 0)
     {
@@ -84,18 +84,18 @@ void GobLang::MemoryNode::setField(std::string const &field, MemoryValue const &
     }
     size_t id = m_fieldNames[field];
     // check if object that we are setting is itself to avoid creating a ref cycle
-    if (value.type == Type::MemoryObj && std::get<MemoryNode *>(value.value) != this)
+    if ((Type)value.index() == Type::MemoryObj && std::get<MemoryNode *>(value) != this)
     {
-        std::get<MemoryNode *>(value.value)->increaseRefCount();
+        std::get<MemoryNode *>(value)->increaseRefCount();
     }
-    if (m_fields[id].type == Type::MemoryObj && std::get<MemoryNode *>(m_fields[id].value) != this)
+    if ((Type)m_fields[id].index() == Type::MemoryObj && std::get<MemoryNode *>(m_fields[id]) != this)
     {
-        std::get<MemoryNode *>(m_fields[id].value)->decreaseRefCount();
+        std::get<MemoryNode *>(m_fields[id])->decreaseRefCount();
     }
     m_fields[id] = value;
 }
 
-GobLang::MemoryValue GobLang::MemoryNode::getField(std::string const &field)
+GobLang::Value GobLang::MemoryNode::getField(std::string const &field)
 {
     if (m_fieldNames.count(field) == 0)
     {
@@ -123,7 +123,7 @@ bool GobLang::MemoryNode::equalsTo(MemoryNode *other)
 std::string GobLang::MemoryNode::toString(bool pretty, size_t depth)
 {
     std::string start = "{";
-    for (std::vector<MemoryValue>::const_iterator it = m_fields.begin(); it != m_fields.end(); it++)
+    for (std::vector<Value>::const_iterator it = m_fields.begin(); it != m_fields.end(); it++)
     {
         start += m_struct->fields[it - m_fields.begin()].name + "=" + valueToString(*it, pretty, depth);
 
@@ -134,11 +134,11 @@ std::string GobLang::MemoryNode::toString(bool pretty, size_t depth)
 
 GobLang::MemoryNode::~MemoryNode()
 {
-    for (std::vector<MemoryValue>::iterator it = m_fields.begin(); it != m_fields.end(); it++)
+    for (std::vector<Value>::iterator it = m_fields.begin(); it != m_fields.end(); it++)
     {
-        if (it->type == Type::MemoryObj)
+        if ((Type)it->index() == Type::MemoryObj)
         {
-            std::get<MemoryNode *>(it->value)->decreaseRefCount();
+            std::get<MemoryNode *>((*it))->decreaseRefCount();
         }
     }
 }

--- a/execution/Memory.hpp
+++ b/execution/Memory.hpp
@@ -7,7 +7,6 @@
 #include "Structure.hpp"
 namespace GobLang
 {
-    struct MemoryValue;
     /**
      * @brief Represents a complex data object that is stored in the memory via a linked list.
      *
@@ -68,12 +67,12 @@ namespace GobLang
         /// @brief Set value of the field if that field exists
         /// @param field Name of the field
         /// @param value Value to assign
-        virtual void setField(std::string const &field, MemoryValue const &value);
+        virtual void setField(std::string const &field, Value const &value);
 
         /// @brief Get value of the field with a given name
         /// @param field Name of the field
         /// @return
-        virtual MemoryValue getField(std::string const &field);
+        virtual Value getField(std::string const &field);
 
         /**
          * @brief Size of the memory chain
@@ -117,7 +116,7 @@ namespace GobLang
         Struct::Structure const *m_struct = nullptr;
 
         /// @brief Storage for the values that an object might have
-        std::vector<MemoryValue> m_fields;
+        std::vector<Value> m_fields;
         /// @brief Name to id mapping of the fields used for access
         std::map<std::string, size_t> m_fieldNames;
     };

--- a/execution/NativeStructure.cpp
+++ b/execution/NativeStructure.cpp
@@ -2,11 +2,11 @@
 #include "Machine.hpp"
 #include "FunctionRef.hpp"
 
-GobLang::MemoryValue GobLang::Struct::NativeStructureObjectNode::getField(std::string const &field)
+GobLang::Value GobLang::Struct::NativeStructureObjectNode::getField(std::string const &field)
 {
     if (m_nativeStruct->methods.contains(field))
     {
-        return MemoryValue{.type = Type::MemoryObj, .value = new FunctionRef(&m_nativeStruct->methods.at(field), this)};
+        return Value(new FunctionRef(&m_nativeStruct->methods.at(field), this));
     }
     return MemoryNode::getField(field);
 }

--- a/execution/NativeStructure.hpp
+++ b/execution/NativeStructure.hpp
@@ -21,7 +21,7 @@ namespace GobLang::Struct
             NativeStructureInfo const *info,
             Structure const *baseInfo = nullptr) : MemoryNode(baseInfo), m_nativeStruct(info) {}
 
-        MemoryValue getField(std::string const &field) override;
+        Value getField(std::string const &field) override;
 
 
     private:

--- a/execution/Type.hpp
+++ b/execution/Type.hpp
@@ -6,8 +6,8 @@ namespace GobLang
     enum class Type
     {
         Null,
-        Char,
         Bool,
+        Char,
         Float,
         Int,
         UnsignedInt,

--- a/execution/Value.cpp
+++ b/execution/Value.cpp
@@ -1,28 +1,28 @@
 #include "Value.hpp"
 #include "Memory.hpp"
 #include <iostream>
-bool GobLang::areEqual(MemoryValue const &a, MemoryValue const &b)
+bool GobLang::areEqual(Value const &a, Value const &b)
 {
-    if (a.type != b.type)
+    if (a.index() != b.index())
     {
         return false;
     }
-    switch (a.type)
+    switch ((Type)a.index())
     {
     case Type::Null:
         return true;
     case Type::Bool:
-        return std::get<bool>(a.value) == std::get<bool>(b.value);
+        return std::get<bool>(a) == std::get<bool>(b);
     case Type::Float:
-        return std::get<float>(a.value) == std::get<float>(b.value);
+        return std::get<float>(a) == std::get<float>(b);
     case Type::Int:
-        return std::get<int32_t>(a.value) == std::get<int32_t>(b.value);
+        return std::get<int32_t>(a) == std::get<int32_t>(b);
     case Type::UnsignedInt:
-        return std::get<uint32_t>(a.value) == std::get<uint32_t>(b.value);
+        return std::get<uint32_t>(a) == std::get<uint32_t>(b);
     case Type::Char:
-        return std::get<char>(a.value) == std::get<char>(b.value);
+        return std::get<char>(a) == std::get<char>(b);
     case Type::MemoryObj:
-        return std::get<MemoryNode *>(a.value)->equalsTo(std::get<MemoryNode *>(b.value));
+        return std::get<MemoryNode *>(a)->equalsTo(std::get<MemoryNode *>(b));
     case Type::NativeFunction:
         // c++ has no equality check for std::function
         return false;
@@ -30,28 +30,28 @@ bool GobLang::areEqual(MemoryValue const &a, MemoryValue const &b)
     return false;
 }
 
-std::string GobLang::valueToString(MemoryValue const &val, bool pretty, size_t depth)
-{   
-    if(depth > MAX_PRINT_RECURSION_DEPTH)
+std::string GobLang::valueToString(Value const &val, bool pretty, size_t depth)
+{
+    if (depth > MAX_PRINT_RECURSION_DEPTH)
     {
         return "...";
     }
-    switch (val.type)
+    switch ((Type)val.index())
     {
     case Type::Null:
         return "null";
     case Type::Bool:
-        return std::get<bool>(val.value) ? "true" : "false";
+        return std::get<bool>(val) ? "true" : "false";
     case Type::Float:
-        return std::to_string(std::get<float>(val.value));
+        return std::to_string(std::get<float>(val));
     case Type::Int:
-        return std::to_string(std::get<int32_t>(val.value));
+        return std::to_string(std::get<int32_t>(val));
     case Type::UnsignedInt:
-        return std::to_string(std::get<uint32_t>(val.value));
+        return std::to_string(std::get<uint32_t>(val));
     case Type::MemoryObj:
-        return std::get<MemoryNode *>(val.value)->toString(pretty, depth + 1);
+        return std::get<MemoryNode *>(val)->toString(pretty, depth + 1);
     case Type::Char:
-        return std::string{std::get<char>(val.value)};
+        return std::string{std::get<char>(val)};
     case Type::NativeFunction:
         // c++ has no equality check for std::function
         return "Native function";

--- a/execution/Value.hpp
+++ b/execution/Value.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <vector>
 #include <cstdint>
+#include <cstddef>
 #include <functional>
 #include <variant>
 #include <string>
@@ -17,13 +18,9 @@ namespace GobLang
     class Machine;
     class MemoryNode;
     using FunctionValue = void (*)(Machine *);
-    using Value = std::variant<bool, char, float, int32_t, uint32_t, MemoryNode *, FunctionValue>;
+    using Value = std::variant<nullptr_t, bool, char, float, int32_t, uint32_t, MemoryNode *, FunctionValue>;
 
-    struct MemoryValue
-    {
-        Type type;
-        Value value;
-    };
+
 
     /**
      * @brief Compare two memory values and validate that both are equal
@@ -33,7 +30,7 @@ namespace GobLang
      * @return true
      * @return false
      */
-    bool areEqual(MemoryValue const &a, MemoryValue const &b);
+    bool areEqual(Value const &a, Value const &b);
 
     /**
      * @brief Create a string representation of a given value
@@ -42,5 +39,5 @@ namespace GobLang
      * @param pretty Whether to add decorators. Only is relevant for strings during printing
      * @return std::string
      */
-    std::string valueToString(MemoryValue const &val, bool pretty, size_t depth);
+    std::string valueToString(Value const &val, bool pretty, size_t depth);
 }

--- a/standard/MachineFunctions.cpp
+++ b/standard/MachineFunctions.cpp
@@ -17,129 +17,95 @@ void MachineFunctions::bind(GobLang::Machine *machine)
     machine->addFunction(MachineFunctions::Math::randomIntInRange, "rand_range");
     machine->addFunction(MachineFunctions::Math::randomInt, "rand");
 
-    machine->createType("File", File::FileNode::constructor, {
-        {"close", File::FileNode::nativeCloseFile},
-        {"write", File::FileNode::nativeWriteToFile},
-        {"is_eof", File::FileNode::nativeIsFileEnded},
-        {"read_line", File::FileNode::nativeReadLineFromFile},
-        {"is_open", File::FileNode::nativeIsFileOpen}
-    });
+    machine->createType("File", File::FileNode::constructor, {{"close", File::FileNode::nativeCloseFile}, {"write", File::FileNode::nativeWriteToFile}, {"is_eof", File::FileNode::nativeIsFileEnded}, {"read_line", File::FileNode::nativeReadLineFromFile}, {"is_open", File::FileNode::nativeIsFileOpen}});
 }
 void MachineFunctions::printLine(GobLang::Machine *machine)
 
 {
-    GobLang::MemoryValue *v = machine->getStackTopAndPop();
-    if (v == nullptr)
-    {
-        std::cerr << "Invalid value to print" << std::endl;
-        return;
-    }
-    std::cout << GobLang::valueToString(*v, false, 0) << std::endl;
-    delete v;
+    GobLang::Value v = machine->getStackTopAndPop();
+    std::cout << GobLang::valueToString(v, false, 0) << std::endl;
 }
 
 void MachineFunctions::print(GobLang::Machine *machine)
 {
-    GobLang::MemoryValue *v = machine->getStackTopAndPop();
-    if (v == nullptr)
-    {
-        std::cerr << "Invalid value to print" << std::endl;
-        return;
-    }
-    std::cout << GobLang::valueToString(*v, false, 0);
-    delete v;
+    std::cout << GobLang::valueToString(machine->getStackTopAndPop(), false, 0);
 }
 
 void MachineFunctions::createArrayOfSize(GobLang::Machine *machine)
 {
-    GobLang::MemoryValue *sizeVal = machine->getStackTopAndPop();
-    machine->pushToStack(GobLang::MemoryValue{
-        .type = GobLang::Type::MemoryObj,
-        .value = machine->createArrayOfSize(std::get<int32_t>(sizeVal->value))});
-    delete sizeVal;
+    GobLang::Value sizeVal = machine->getStackTopAndPop();
+    machine->pushToStack(GobLang::Value(machine->createArrayOfSize(std::get<int32_t>(sizeVal))));
 }
 
 void MachineFunctions::append(GobLang::Machine *machine)
 {
     using namespace GobLang;
-    GobLang::MemoryValue *val = machine->getStackTopAndPop();
-    GobLang::MemoryValue *array = machine->getStackTopAndPop();
-
-    if (array == nullptr || array->type != Type::MemoryObj)
+    GobLang::Value val = machine->getStackTopAndPop();
+    if (ArrayNode *arrayNode = machine->popObjectFromStack<ArrayNode>(); arrayNode != nullptr)
+    {
+        arrayNode->append(val);
+    }
+    else
     {
         throw GobLang::RuntimeException("Attempted to append to a non array object");
     }
-    if (val == nullptr)
-    {
-        throw GobLang::RuntimeException("Missing value for the append operation");
-    }
-    if (GobLang::ArrayNode *arrayNode = dynamic_cast<GobLang::ArrayNode *>(std::get<GobLang::MemoryNode *>(array->value)); arrayNode != nullptr)
-    {
-        arrayNode->append(*val);
-    }
-    delete val;
-    delete array;
 }
 
 void MachineFunctions::getSizeof(GobLang::Machine *machine)
 {
-    GobLang::MemoryValue *array = machine->getStackTopAndPop();
-    if (array->type != GobLang::Type::MemoryObj)
+    GobLang::MemoryNode *array = machine->popFromStack<GobLang::MemoryNode *>();
+    if (array == nullptr)
     {
         throw GobLang::RuntimeException("Attempted to get a size of a non array object");
     }
-    if (GobLang::ArrayNode *arrayNode = dynamic_cast<GobLang::ArrayNode *>(std::get<GobLang::MemoryNode *>(array->value)); arrayNode != nullptr)
+    if (GobLang::ArrayNode *arrayNode = dynamic_cast<GobLang::ArrayNode *>(array); arrayNode != nullptr)
     {
-        machine->pushToStack(GobLang::MemoryValue{.type = GobLang::Type::Int, .value = (int32_t)arrayNode->getSize()});
+        machine->pushToStack(GobLang::Value((int32_t)arrayNode->getSize()));
     }
-    else if (GobLang::StringNode *strNode = dynamic_cast<GobLang::StringNode *>(std::get<GobLang::MemoryNode *>(array->value)); strNode != nullptr)
+    else if (GobLang::StringNode *strNode = dynamic_cast<GobLang::StringNode *>(array); strNode != nullptr)
     {
-        machine->pushToStack(GobLang::MemoryValue{.type = GobLang::Type::Int, .value = (int32_t)strNode->getSize()});
+        machine->pushToStack(GobLang::Value((int32_t)strNode->getSize()));
     }
-    delete array;
 }
 
 void MachineFunctions::toString(GobLang::Machine *machine)
 {
-    GobLang::MemoryValue *val = machine->getStackTopAndPop();
-    machine->pushToStack(GobLang::MemoryValue{
-        .type = GobLang::Type::MemoryObj,
-        .value = machine->createString(GobLang::valueToString(*val, false, 0))});
-    delete val;
+    GobLang::Value val = machine->getStackTopAndPop();
+    machine->pushToStack(GobLang::Value(machine->createString(GobLang::valueToString(val, false, 0))));
 }
 
 void MachineFunctions::input(GobLang::Machine *machine)
 {
     std::string input;
     getline(std::cin, input);
-    machine->pushToStack(GobLang::MemoryValue{.type = GobLang::Type::MemoryObj, .value = machine->createString(input)});
+    machine->pushToStack(GobLang::Value(machine->createString(input)));
 }
 
 void MachineFunctions::inputChar(GobLang::Machine *machine)
 {
     char ch;
     std::cin >> ch;
-    machine->pushToStack(GobLang::MemoryValue{.type = GobLang::Type::Char, .value = ch});
+    machine->pushToStack(GobLang::Value(ch));
 }
 
 void MachineFunctions::Math::toInt(GobLang::Machine *machine)
 {
     using namespace GobLang;
-    MemoryValue *value = machine->getStackTopAndPop();
-    switch (value->type)
+    Value value = machine->getStackTopAndPop();
+    switch ((Type)value.index())
     {
     case Type::Int:
-        machine->pushToStack(*value);
+        machine->pushToStack(value);
         break;
     case GobLang::Type::Float:
-        machine->pushToStack(MemoryValue{.type = Type::Int, .value = (int32_t)std::get<float>(value->value)});
+        machine->pushToStack(Value((int32_t)std::get<float>(value)));
         break;
     case GobLang::Type::MemoryObj:
         try
         {
-            if (StringNode *node = dynamic_cast<StringNode *>(std::get<MemoryNode *>(value->value)); node != nullptr)
+            if (StringNode *node = dynamic_cast<StringNode *>(std::get<MemoryNode *>(value)); node != nullptr)
             {
-                machine->pushToStack(MemoryValue{.type = Type::Int, .value = std::stoi(node->getString())});
+                machine->pushToStack(Value(std::stoi(node->getString())));
                 break;
             }
         }
@@ -152,29 +118,28 @@ void MachineFunctions::Math::toInt(GobLang::Machine *machine)
             throw RuntimeException(std::string("Unable to convert string to int. ") + e.what());
         }
     default:
-        throw RuntimeException(std::string("Unable to convert type ") + typeToString(value->type) + " to int");
+        throw RuntimeException(std::string("Unable to convert type ") + typeToString((Type)value.index()) + " to int");
     }
-    delete value;
 }
 
 void MachineFunctions::Math::toFloat(GobLang::Machine *machine)
 {
     using namespace GobLang;
-    MemoryValue *value = machine->getStackTopAndPop();
-    switch (value->type)
+    Value value = machine->getStackTopAndPop();
+    switch ((Type)value.index())
     {
     case Type::Int:
-        machine->pushToStack(MemoryValue{.type = Type::Float, .value = (float)std::get<float>(value->value)});
+        machine->pushToStack(Value(std::get<int32_t>(value)));
         break;
     case GobLang::Type::Float:
-        machine->pushToStack(*value);
+        machine->pushToStack(value);
         break;
     case GobLang::Type::MemoryObj:
         try
         {
-            if (StringNode *node = dynamic_cast<StringNode *>(std::get<MemoryNode *>(value->value)); node != nullptr)
+            if (StringNode *node = dynamic_cast<StringNode *>(std::get<MemoryNode *>(value)); node != nullptr)
             {
-                machine->pushToStack(MemoryValue{.type = Type::Float, .value = std::stof(node->getString())});
+                machine->pushToStack(Value(std::stof(node->getString())));
                 break;
             }
         }
@@ -187,32 +152,22 @@ void MachineFunctions::Math::toFloat(GobLang::Machine *machine)
             throw RuntimeException(std::string("Unable to convert string to float. ") + e.what());
         }
     default:
-        throw RuntimeException(std::string("Unable to convert type ") + typeToString(value->type) + " to float");
+        throw RuntimeException(std::string("Unable to convert type ") + typeToString((Type)value.index()) + " to float");
     }
-    delete value;
 }
 
 void MachineFunctions::Math::randomIntInRange(GobLang::Machine *machine)
 {
-    GobLang::MemoryValue *max = machine->getStackTopAndPop();
-    GobLang::MemoryValue *min = machine->getStackTopAndPop();
-    if (min->type != GobLang::Type::Int || max->type != GobLang::Type::Int)
+    int32_t max = machine->popFromStack<int32_t>();
+    int32_t min = machine->popFromStack<int32_t>();
+    if (min >= max)
     {
-        throw GobLang::RuntimeException("Random value range values are not type int");
-    }
-    int32_t minVal = std::get<int32_t>(min->value);
-    int32_t maxVal = std::get<int32_t>(max->value);
-    if (minVal >= maxVal)
-    {
-        throw GobLang::RuntimeException(std::string("Invalid random range. Min: " + std::to_string(minVal) + " max: " + std::to_string(maxVal)));
+        throw GobLang::RuntimeException(std::string("Invalid random range. Min: " + std::to_string(min) + " max: " + std::to_string(max)));
     }
     std::random_device rand_dev;
     std::mt19937 generator(rand_dev());
-    std::uniform_int_distribution<int32_t> distr(std::get<int32_t>(min->value), std::get<int32_t>(max->value));
-    machine->pushToStack(GobLang::MemoryValue{.type = GobLang::Type::Int, .value = distr(generator)});
-
-    delete min;
-    delete max;
+    std::uniform_int_distribution<int32_t> distr(min, max);
+    machine->pushToStack(GobLang::Value(distr(generator)));
 }
 
 void MachineFunctions::Math::randomInt(GobLang::Machine *machine)
@@ -221,5 +176,5 @@ void MachineFunctions::Math::randomInt(GobLang::Machine *machine)
     std::mt19937 generator(rand_dev());
 
     std::uniform_int_distribution<int32_t> distr(DEFAULT_MIN_RAND_INT, DEFAULT_MAX_RAND_INT);
-    machine->pushToStack(GobLang::MemoryValue{.type = GobLang::Type::Int, .value = distr(generator)});
+    machine->pushToStack(GobLang::Value(distr(generator)));
 }


### PR DESCRIPTION
The purpose of this change is to update the memory system to use a more sane approach which uses existing c++ tools, instead of building similar ones on top of them

This reduces the size of each value by 2 and also means that tools for `std::variant` can be used directly. This also adds more QOL functions for interacting with interpreter